### PR TITLE
Rails support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 spec/examples.txt
 .yardoc
 doc
+log

--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,7 @@ namespace :spec do
   TEST_APPS = %i(
     sinatra_activerecord
     sinatra_sequel
+    rails_activerecord
   )
 
   TEST_APPS.each do |app|

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'libhoney', '>= 1.8.1'
 
-  gem.add_dependency 'activerecord-honeycomb', '>= 0.2.1'
-  gem.add_dependency 'rack-honeycomb', '>= 0.2.1'
+  gem.add_dependency 'activerecord-honeycomb', '>= 0.3.0'
+  gem.add_dependency 'rack-honeycomb', '>= 0.3.0'
   gem.add_dependency 'faraday-honeycomb', '>= 0.2.1'
   gem.add_dependency 'sequel-honeycomb', '>= 0.2.1'
 

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.authors = ['Sam Stokes']
   gem.email = %w(support@honeycomb.io)
   gem.homepage = 'https://github.com/honeycombio/beeline-ruby'
-  gem.license = 'MIT'
+  gem.license = 'Apache-2.0'
 
 
   gem.add_dependency 'libhoney', '>= 1.8.1'

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pg'
   gem.add_development_dependency 'rack'
   gem.add_development_dependency 'rack-test'
+  gem.add_development_dependency 'rails'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sinatra'

--- a/spec/instrumented_apps/rails_activerecord/app.rb
+++ b/spec/instrumented_apps/rails_activerecord/app.rb
@@ -1,0 +1,107 @@
+require 'rails'
+require 'action_controller/railtie'
+require 'active_record/railtie'
+
+require 'honeycomb-beeline'
+
+require 'support/db_active_record'
+require 'support/fake_auth'
+require 'support/fakehoney'
+require 'support/only_one_app'
+
+Honeycomb.init service_name: 'rails_activerecord', client: $fakehoney
+
+class RailsActiveRecordApp < Rails::Application
+  include ThereCanBeOnlyOneApp
+
+  # some minimal config Rails expects to be present
+  if Rails::VERSION::MAJOR < 4
+    config.secret_token = 'test' * 8
+  else
+    config.secret_key_base = 'test'
+  end
+
+  config.eager_load = true
+
+  # override Rails DB config to use our test DB
+  # (normally Rails would look in config/database.yml)
+  def config.database_configuration
+    TestDB::ActiveRecord.config
+  end
+
+  routes.append do
+    post '/login', to: 'sessions#create'
+
+    resources :animals do
+      get '/remote', action: :index_remote, on: :collection
+    end
+
+    if Rails::VERSION::MAJOR < 4
+      root to: 'hello#index'
+    else
+      root 'hello#index'
+    end
+  end
+
+  FAKE_AUTH = FakeAuth::Client.new
+end
+
+class ApplicationController < ActionController::Base
+  def render_plain(text)
+    if Rails::VERSION::MAJOR < 4
+      render text: text
+    else
+      render plain: text
+    end
+  end
+end
+
+class HelloController < ApplicationController
+  def index
+    render_plain 'hello'
+  end
+end
+
+class SessionsController < ApplicationController
+  def create
+    user = RailsActiveRecordApp::FAKE_AUTH.login
+    render_plain "logged in as #{user.fetch('username')}"
+  end
+end
+
+class AnimalsController < ApplicationController
+  def index_remote
+    # simulate user instrumentation for calling a couple of microservices
+    animals1 = span name: :reindeer_games_service do
+      %w(Dasher Dancer Prancer Vixen Comet Cupid Donner Blitzen).map do |name|
+        Animal.new name: name, species: 'Reindeer'
+      end
+    end
+
+    animals2 = span name: :nose_so_bright_service do
+      [Animal.new(name: 'Rudolph', species: 'Reindeer')]
+    end
+
+    span name: :render_json do
+      render json: (animals1 + animals2)
+    end
+  end
+
+  def create
+    # N.B. this is not actually a correct way to do "add a new record if one
+    # doesn't already exist", but this is an example of ActiveRecord usage,
+    # not of concurrency-safe database best practices!
+
+    if animal = Animal.find_by(name: params.require(:name))
+      render status: :accepted, json: animal
+    else
+      animal = Animal.create!(params.permit(:name, :species))
+      render status: :created, json: animal
+    end
+  end
+
+  private
+  def span(name:)
+    Honeycomb.span(service_name: :rails_activerecord, name: name) { yield }
+  end
+end

--- a/spec/support/db_active_record.rb
+++ b/spec/support/db_active_record.rb
@@ -2,6 +2,8 @@ require 'active_record'
 
 require 'support/db'
 
+ENV['RAILS_ENV'] = 'test'
+
 module TestDB
   module ActiveRecord
     class << self
@@ -12,7 +14,8 @@ module TestDB
       end
 
       def establish_connection
-        @connection_pool = ::ActiveRecord::Base.establish_connection(config.fetch('test'))
+        ::ActiveRecord::Base.configurations = config
+        @connection_pool = ::ActiveRecord::Base.establish_connection#(config.fetch('test'))
       end
 
       def disconnect

--- a/spec/support/fake_auth.rb
+++ b/spec/support/fake_auth.rb
@@ -1,0 +1,24 @@
+require 'faraday'
+
+module FakeAuth
+  class Error < RuntimeError; end
+
+  class Client
+    def initialize
+      @http = Faraday.new('https://auth.example.com') do |conn|
+        conn.adapter :test do |stub|
+          stub.post('/login') { [200, {}, {username: 'Bob'}.to_json] }
+        end
+      end
+    end
+
+    def login
+      response = @http.post('/login')
+      if response.status == 200
+        JSON.parse(response.body)
+      else
+        raise Error, 'login failed'
+      end
+    end
+  end
+end


### PR DESCRIPTION
![2018-10-22-210645_2280x313_scrot](https://user-images.githubusercontent.com/20528/47330603-6ecc4f80-d63e-11e8-9ede-5ca8157cd4a1.png)

The Beeline itself doesn't actually need any changes to support Rails, so this PR serves mainly as instructions for tying together the changes needed to the instrumentation repos: https://github.com/honeycombio/rack-honeycomb/pull/8 and https://github.com/honeycombio/activerecord-honeycomb/pull/2. This PR also adds integration tests to verify that the Beeline's auto-install works correctly for a Rails/ActiveRecord app.

### Recommended steps to merge

The CI build for this PR will not currently pass, because the Rails integration tests depend on the aforementioned PRs to rack-honeycomb and activerecord-honeycomb. So recommended steps to merge and release Rails support:

 1. merge https://github.com/honeycombio/rack-honeycomb/pull/8 and publish a new release of rack-honeycomb (say, rack-honeycomb 0.3.0)
 2. merge https://github.com/honeycombio/activerecord-honeycomb/pull/2 and publish a new release of activerecord-honeycomb (say, activerecord-honeycomb 0.3.0)
 3. ask TravisCI to rerun the CI build for this PR - it will pull the newly released activerecord-honeycomb and rack-honeycomb and the Rails integration tests should pass.
 4. merge this PR.
 5. bump the [version requirements in honeycomb-beeline.gemspec](https://github.com/honeycombio/beeline-ruby/blob/master/honeycomb-beeline.gemspec#L24-L25) for activerecord-honeycomb and rack-honeycomb (e.g. to `'>= 0.3.0'`) so that the Beeline gem requires the newly released instrumentation gems.
 6. publish a new release of honeycomb-beeline.

Once that's done, anyone installing the Beeline (or updating an existing install) will get the Rails-aware version of all three gems.

### Testing on a Rails app

If you want to try this out on an actual Rails app before doing the above merge sequence, the easiest way will be to point the Rails app at the relevant branches on Github. Add the following to the Rails app's `Gemfile` (replacing any existing `gem 'honeycomb-beeline'` line present):

```ruby
gem 'honeycomb-beeline', git: 'https://github.com/honeycombio/beeline-ruby', branch: 'sam.rails'
gem 'rack-honeycomb', git: 'https://github.com/honeycombio/rack-honeycomb', branch: 'sam.rails'
gem 'activerecord-honeycomb', git: 'https://github.com/honeycombio/activerecord-honeycomb', branch: 'sam.binds'
```

Then run `bundle install` in the Rails app's root directory - Bundler will (behind the scenes) clone all three repos and check out the requested branches, so that when you run the Rails app it will use the branches instead of the released gems.