### PR TITLE
Tracing API and cross-process tracing

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'libhoney', '>= 1.8.1'
 
-  gem.add_dependency 'activerecord-honeycomb', '>= 0.3.0'
-  gem.add_dependency 'rack-honeycomb', '>= 0.3.0'
-  gem.add_dependency 'faraday-honeycomb', '>= 0.2.1'
-  gem.add_dependency 'sequel-honeycomb', '>= 0.2.1'
+  gem.add_dependency 'activerecord-honeycomb', '>= 0.4.0'
+  gem.add_dependency 'rack-honeycomb', '>= 0.4.0'
+  gem.add_dependency 'faraday-honeycomb', '>= 0.3.0'
+  gem.add_dependency 'sequel-honeycomb', '>= 0.4.0'
 
 
   gem.add_development_dependency 'activerecord'

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -72,7 +72,7 @@ module Honeycomb
       @client = new_client(options)
 
       after_init_hooks.each do |label, block|
-        @logger.debug "Running hook '#{label}' after Honeycomb.init" if @logger
+        debug "Running hook '#{label}' after Honeycomb.init"
         run_hook(label, block)
       end
 
@@ -106,6 +106,16 @@ module Honeycomb
     end
 
     private
+    def debug(msg)
+      logger.debug msg if logger
+    end
+    def info(msg)
+      logger.info msg if logger
+    end
+    def warn(msg)
+      logger.warn msg if logger
+    end
+
     def after_init_hooks
       @after_init_hooks ||= []
     end
@@ -116,13 +126,13 @@ module Honeycomb
       options = {user_agent_addition: USER_AGENT_SUFFIX}.merge(options)
       if @debug
         raise ArgumentError, "can't specify both client and debug options", caller if client
-        @logger.info 'logging events to standard error instead of sending to Honeycomb' if @logger
+        info 'logging events to standard error instead of sending to Honeycomb'
         client = Libhoney::LogClient.new(verbose: true, **options)
       else
         client ||= if options[:writekey] && options[:dataset]
           Libhoney::Client.new(options)
         else
-          @logger.warn "#{self.name}: no #{options[:writekey] ? 'dataset' : 'writekey'} configured, disabling sending events" if @logger
+          warn "#{self.name}: no #{options[:writekey] ? 'dataset' : 'writekey'} configured, disabling sending events"
           Libhoney::NullClient.new(options)
         end
       end
@@ -146,7 +156,7 @@ module Honeycomb
              end
 
       if defined?(@initialized)
-        @logger.debug "Running hook '#{label}' as Honeycomb already initialized" if @logger
+        debug "Running hook '#{label}' as Honeycomb already initialized"
         run_hook(label, hook)
       else
         after_init_hooks << [label, hook]
@@ -155,12 +165,12 @@ module Honeycomb
 
     def run_hook(label, block)
       if @without.include?(label)
-        @logger.debug "Skipping hook '#{label}' due to opt-out" if @logger
+        debug "Skipping hook '#{label}' due to opt-out"
       else
         block.call @client, @logger
       end
     rescue => e
-      @logger.warn "Honeycomb.init hook '#{label}' raised #{e.class}: #{e}" if @logger
+      warn "Honeycomb.init hook '#{label}' raised #{e.class}: #{e}"
     end
   end
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -4,46 +4,39 @@ require 'securerandom'
 
 module Honeycomb
   class << self
-    # @api private
-    def with_trace_context(encoded_context = nil)
-      trace_context = decode_trace_context(encoded_context) || {}
-      trace_id = trace_context.fetch(:trace_id, SecureRandom.uuid)
-      parent_span_id = trace_context[:parent_span_id]
-      context = trace_context.fetch(:context, {})
+    def trace(trace_id: nil, parent_span_id: nil, context: {}, **extra_context)
+      context = context.merge(extra_context)
 
-      Thread.current[:honeycomb_trace_id] = trace_id
-      yield trace_id, parent_span_id, context
-    ensure
-      Thread.current[:honeycomb_trace_id] = nil
-    end
-
-    # @api private
-    def trace_id
-      Thread.current[:honeycomb_trace_id]
-    end
-
-    # @api private
-    def with_span_id(span_id)
-      parent_span_id = Thread.current[:honeycomb_span_id]
-      Thread.current[:honeycomb_span_id] = span_id
-      yield parent_span_id
-    ensure
-      Thread.current[:honeycomb_span_id] = parent_span_id
-    end
-
-    # @api private
-    def span(service_name:, name:, span_id: SecureRandom.uuid)
-      event = client.event
-
-      event.add_field 'trace.trace_id', trace_id if trace_id
-      event.add_field 'service_name', service_name
-      event.add_field 'name', name
-      event.add_field 'trace.span_id', span_id
-
-      start = Time.now
-      with_span_id(span_id) do |parent_span_id|
-        event.add_field 'trace.parent_id', parent_span_id if parent_span_id
+      with_trace trace_id: trace_id, parent_span_id: parent_span_id, context: context do
         yield
+      end
+    end
+
+    def trace_from_encoded_context(encoded_context = nil, additional_context: {})
+      trace_context = decode_trace_context(encoded_context) || {}
+      trace_id = trace_context[:trace_id]
+      parent_span_id = trace_context[:parent_span_id]
+      context = trace_context[:context] || {}
+
+      trace(trace_id: trace_id, parent_span_id: parent_span_id, context: context.merge(additional_context)) do
+        yield
+      end
+    end
+
+    def span(name = nil, type: 'app', fields: {}, **extra_fields)
+      fields = fields.merge(extra_fields)
+
+      start = nil
+
+      event = client.event
+      span_for_existing_event(event, name: name, type: type) do |span_id, trace_id|
+        fields.each do |field, value|
+          event.add_field "app.#{field}", value
+        end
+
+        start = Time.now
+
+        yield span_id, trace_id
       end
     rescue Exception => e
       if event
@@ -59,6 +52,30 @@ module Honeycomb
         event.add_field 'duration_ms', duration * 1000
         event.send
       end
+    end
+
+    # TODO give me a better name
+    def span_for_existing_event(event, name:, type:)
+      with_trace do |trace_id, context|
+        with_span do |parent_span_id, span_id|
+          event.add_field 'trace.trace_id', trace_id
+          event.add_field 'trace.parent_id', parent_span_id if parent_span_id
+          event.add_field 'trace.span_id', span_id
+          event.add_field 'name', name if name
+          event.add_field 'type', type
+
+          context.each do |field, value|
+            event.add_field "app.#{field}", value
+          end
+
+          yield span_id, trace_id
+        end
+      end
+    end
+
+    def add_trace_field(name, value)
+      self.active_trace_context[name] = value
+      # TODO also add to active span event
     end
 
     def decode_trace_context(encoded_context)
@@ -85,7 +102,73 @@ module Honeycomb
     end
     alias encode_trace_context encode_trace_context_v1
 
+    def active_trace_id
+      Thread.current[:honeycomb_trace_id]
+    end
+    def active_trace_id=(trace_id)
+      Thread.current[:honeycomb_trace_id] = trace_id
+    end
+
+    def active_parent_span_id
+      Thread.current[:honeycomb_parent_span_id]
+    end
+    def active_parent_span_id=(parent_span_id)
+      Thread.current[:honeycomb_parent_span_id] = parent_span_id
+    end
+
+    def active_trace_context
+      Thread.current[:honeycomb_trace_context]
+    end
+    def active_trace_context=(trace_context)
+      Thread.current[:honeycomb_trace_context] = trace_context
+    end
+
     private
+    def with_trace(trace_id: nil, parent_span_id: nil, context: nil)
+      if self.active_trace_id
+        yield self.active_trace_id, self.active_trace_context
+      else
+        begin
+          trace_id, context = start_trace!(trace_id: trace_id, parent_span_id: parent_span_id, context: context)
+
+          yield trace_id, context
+        ensure
+          finish_trace!
+        end
+      end
+    end
+
+    def start_trace!(trace_id: nil, parent_span_id: nil, context: nil)
+      raise "#{self}.start_trace! called while another trace is already active" if self.active_trace_id
+
+      trace_id ||= SecureRandom.uuid
+      self.active_trace_id = trace_id
+
+      self.active_parent_span_id = parent_span_id if parent_span_id
+
+      context ||= {}
+      self.active_trace_context = context
+
+      [trace_id, context]
+    end
+
+    def finish_trace!
+      self.active_trace_id = nil
+      self.active_parent_span_id = nil
+      self.active_trace_context = nil
+    end
+
+    def with_span
+      span_id = SecureRandom.uuid
+
+      parent_span_id = self.active_parent_span_id
+      self.active_parent_span_id = span_id
+
+      yield parent_span_id, span_id
+    ensure
+      self.active_parent_span_id = parent_span_id
+    end
+
     def decode_payload_v1(encoded_payload)
       trace_id, parent_span_id, context = nil
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -159,13 +159,23 @@ module Honeycomb
     end
 
     def with_span
+      parent_span_id, span_id = start_span!
+
+      yield parent_span_id, span_id
+    ensure
+      finish_span!(parent_span_id)
+    end
+
+    def start_span!
       span_id = SecureRandom.uuid
 
       parent_span_id = self.active_parent_span_id
       self.active_parent_span_id = span_id
 
-      yield parent_span_id, span_id
-    ensure
+      return parent_span_id, span_id
+    end
+
+    def finish_span!(parent_span_id)
       self.active_parent_span_id = parent_span_id
     end
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -1,11 +1,18 @@
+require 'base64'
+require 'json'
 require 'securerandom'
 
 module Honeycomb
   class << self
     # @api private
-    def with_trace_id(trace_id = SecureRandom.uuid)
+    def with_trace_context(encoded_context = nil)
+      trace_context = decode_trace_context(encoded_context) || {}
+      trace_id = trace_context.fetch(:trace_id, SecureRandom.uuid)
+      parent_span_id = trace_context[:parent_span_id]
+      context = trace_context.fetch(:context, {})
+
       Thread.current[:honeycomb_trace_id] = trace_id
-      yield trace_id
+      yield trace_id, parent_span_id, context
     ensure
       Thread.current[:honeycomb_trace_id] = nil
     end
@@ -51,6 +58,115 @@ module Honeycomb
         duration = finish - start
         event.add_field 'duration_ms', duration * 1000
         event.send
+      end
+    end
+
+    def decode_trace_context(encoded_context)
+      return nil unless encoded_context
+      version, payload = encoded_context.split(';', 2)
+      case version
+      when '1'
+        decode_payload_v1(payload)
+      else
+        nil
+      end
+    end
+
+    def encode_trace_context_v1(trace_id, parent_span_id, context)
+      version = 1
+
+      encoded_payload = encode_payload_v1(
+        trace_id: trace_id,
+        parent_id: parent_span_id,
+        context: context,
+      )
+
+      "#{version};#{encoded_payload}"
+    end
+    alias encode_trace_context encode_trace_context_v1
+
+    private
+    def decode_payload_v1(encoded_payload)
+      trace_id, parent_span_id, context = nil
+
+      encoded_payload.split(',').each do |entry|
+        k, v = entry.split('=', 2)
+        case k
+        when 'trace_id'
+          trace_id = v
+        when 'parent_id'
+          parent_span_id = v
+        when 'context'
+          context = decode_payload_context_v1(v)
+        else
+        end
+      end
+
+      if trace_id.nil?
+        return nil
+      elsif parent_span_id.nil?
+        return nil
+      end
+
+      payload = {
+        trace_id: trace_id,
+        parent_span_id: parent_span_id,
+      }
+      payload[:context] = context if context
+      payload
+    rescue StandardError => e
+      nil
+    end
+
+    def decode_payload_context_v1(encoded_payload_context)
+      return {} if encoded_payload_context.empty?
+      json = Base64.decode64(encoded_payload_context)
+      JSON.parse(json)
+    end
+
+    def encode_payload_v1(payload_parts)
+      payload_parts.map do |k, v|
+        encoded_part = encode_payload_part_v1(k, v)
+        encoded_part ? "#{k}=#{encoded_part}" : nil
+      end
+        .compact # strip out parts that failed to encode
+        .join(',')
+    end
+
+    def encode_payload_part_v1(param, value)
+      case param
+      when :trace_id, :parent_id
+        encode_payload_id_v1(value)
+      when :context
+        encode_payload_context_v1(value)
+      end
+    end
+
+    def encode_payload_id_v1(id)
+      case id
+      when nil
+        nil
+      when String, Symbol
+        id = id.to_s
+        if id.include? ','
+          raise ArgumentError, "can't include ','"
+        end
+        id
+      when Numeric
+        id.to_s
+      else
+        raise ArgumentError, "invalid type #{id.class}"
+      end
+    end
+
+    def encode_payload_context_v1(context)
+      case context
+      when nil
+        nil
+      when Hash
+        Base64.urlsafe_encode64(JSON.generate(context)).strip
+      else
+        raise ArgumentError, "invalid type #{context.class}"
       end
     end
   end

--- a/spec/beeline/span_spec.rb
+++ b/spec/beeline/span_spec.rb
@@ -1,0 +1,98 @@
+require 'honeycomb/span'
+
+RSpec.describe 'trace context' do
+  def encode(*args)
+    Honeycomb.encode_trace_context(*args)
+  end
+
+  def decode(*args)
+    Honeycomb.decode_trace_context(*args)
+  end
+
+  describe 'roundtrip' do
+    specify 'encoding then decoding preserves a context' do
+      trace_id = 'abcdef123456'
+      parent_span_id = '0102030405'
+      context = {
+        'custom_context' => {
+          'user_id' => 1,
+          'error_msg' => 'failed to sign on',
+          'to_retry' => true,
+        },
+      }
+
+      expect(decode(encode(trace_id, parent_span_id, context))).to eq(
+        trace_id: trace_id,
+        parent_span_id: parent_span_id,
+        context: context,
+      )
+    end
+
+    specify 'decoding then encoding preserves an encoded context' do
+      encoded_context = "1;trace_id=abcdef123456,parent_id=0102030405,context=#{Base64.encode64('{"foo":"bar","baz":[1,2,3]}').strip}"
+
+      context = decode(encoded_context)
+      reencoded = encode(context[:trace_id], context[:parent_span_id], context[:context])
+      expect(reencoded).to eq(encoded_context)
+    end
+  end
+
+  describe 'encoding' do
+    it 'encodes as a string' do
+      expect(encode('abcd', 'efgh', foo: 'bar')).to be_a String
+    end
+
+    it 'prefixes with the version' do
+      expect(encode('abcd', 'efgh', foo: 'bar')).to start_with('1')
+    end
+
+    it 'does not add newlines for large contexts' do
+      expect(encode('abcd', 'efgh', foo: 'bar'*32)).to_not include("\n")
+    end
+  end
+
+  describe 'decoding' do
+    [
+      {
+        description: "unsupported version",
+        encoded_context: "9999999;.....",
+        expected: nil,
+      },
+      {
+        description: "v1 trace_id + parent_id, missing context",
+        encoded_context: "1;trace_id=abcdef,parent_id=12345",
+        expected: {
+          trace_id: "abcdef",
+          parent_span_id: "12345",
+        },
+      },
+      {
+        description: "v1, missing trace_id",
+        encoded_context: "1;parent_id=12345",
+        expected: nil,
+      },
+      {
+        description: "v1, missing parent_id",
+        encoded_context: "1;trace_id=12345",
+        expected: nil,
+      },
+      {
+        description: "v1, garbled context",
+        encoded_context: "1;trace_id=abcdef,parent_id=12345,context=123~!@@&^@",
+        expected: nil,
+      },
+      {
+        description: "v1, unknown key (otherwise valid)",
+        encoded_context: "1;trace_id=abcdef,parent_id=12345,something=unsupported",
+        expected: {
+          trace_id: "abcdef",
+          parent_span_id: "12345",
+        },
+      },
+    ].each do |description:, encoded_context:, expected:|
+      it "#{expected ? 'decodes' : 'refuses to decode'} #{description}" do
+        expect(decode(encoded_context)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/instrumented_apps/rails_activerecord/app.rb
+++ b/spec/instrumented_apps/rails_activerecord/app.rb
@@ -8,8 +8,9 @@ require 'support/db_active_record'
 require 'support/fake_auth'
 require 'support/fakehoney'
 require 'support/only_one_app'
+require 'support/test_logger'
 
-Honeycomb.init service_name: 'rails_activerecord', client: $fakehoney
+Honeycomb.init service_name: 'rails_activerecord', client: $fakehoney, logger: $test_logger
 
 class RailsActiveRecordApp < Rails::Application
   include ThereCanBeOnlyOneApp

--- a/spec/instrumented_apps/rails_activerecord/app_spec.rb
+++ b/spec/instrumented_apps/rails_activerecord/app_spec.rb
@@ -109,13 +109,11 @@ RSpec.describe RailsActiveRecordApp do
     let(:events) { $fakehoney.events }
 
     it 'emits user instrumentation events followed by an http_server event' do
-      pending 'span should include type'
-
-      expect(events.map {|event| event.data['type'] }).to eq %w(animals_client animals_client render http_server)
+      expect(events.map {|event| event.data['type'] }).to eq %w(app app app http_server)
     end
 
     it 'includes beeline meta fields in all the events' do
-      pending 'span should include something for meta.package'
+      pending 'span_for_existing_event should include something for meta.package'
 
       expect(events.map(&:data)).to all(include beeline_meta_fields)
       expect(events.map(&:data)).to all(include 'meta.package')

--- a/spec/instrumented_apps/rails_activerecord/app_spec.rb
+++ b/spec/instrumented_apps/rails_activerecord/app_spec.rb
@@ -113,10 +113,7 @@ RSpec.describe RailsActiveRecordApp do
     end
 
     it 'includes beeline meta fields in all the events' do
-      pending 'span_for_existing_event should include something for meta.package'
-
       expect(events.map(&:data)).to all(include beeline_meta_fields)
-      expect(events.map(&:data)).to all(include 'meta.package')
     end
 
     include_examples 'tracing'

--- a/spec/instrumented_apps/sinatra_activerecord/app.rb
+++ b/spec/instrumented_apps/sinatra_activerecord/app.rb
@@ -7,8 +7,9 @@ require 'support/db_active_record'
 require 'support/fake_auth'
 require 'support/fakehoney'
 require 'support/only_one_app'
+require 'support/test_logger'
 
-Honeycomb.init service_name: 'sinatra_activerecord', client: $fakehoney
+Honeycomb.init service_name: 'sinatra_activerecord', client: $fakehoney, logger: $test_logger
 
 class SinatraActiveRecordApp < Sinatra::Base
   include ThereCanBeOnlyOneApp

--- a/spec/instrumented_apps/sinatra_activerecord/app.rb
+++ b/spec/instrumented_apps/sinatra_activerecord/app.rb
@@ -51,23 +51,18 @@ class SinatraActiveRecordApp < Sinatra::Base
   get '/microanimals' do
     # simulate user instrumentation for calling a couple of microservices
 
-    animals1 = span name: :reindeer_games_service do
+    animals1 = Honeycomb.span :reindeer_games_service do
       %w(Dasher Dancer Prancer Vixen Comet Cupid Donner Blitzen).map do |name|
         Animal.new name: name, species: 'Reindeer'
       end
     end
 
-    animals2 = span name: :nose_so_bright_service do
+    animals2 = Honeycomb.span :nose_so_bright_service do
       [Animal.new(name: 'Rudolph', species: 'Reindeer')]
     end
 
-    span name: :render_json do
+    Honeycomb.span :render_json do
       (animals1 + animals2).to_json
     end
-  end
-
-  private
-  def span(name:)
-    Honeycomb.span(service_name: :sinatra_activerecord, name: name) { yield }
   end
 end

--- a/spec/instrumented_apps/sinatra_activerecord/app_spec.rb
+++ b/spec/instrumented_apps/sinatra_activerecord/app_spec.rb
@@ -98,13 +98,11 @@ RSpec.describe SinatraActiveRecordApp do
     let(:events) { $fakehoney.events }
 
     it 'emits user instrumentation events followed by an http_server event' do
-      pending 'span should include type'
-
-      expect(events.map {|event| event.data['type'] }).to eq %w(animals_client animals_client render http_server)
+      expect(events.map {|event| event.data['type'] }).to eq %w(app app app http_server)
     end
 
     it 'includes beeline meta fields in all the events' do
-      pending 'span should include something for meta.package'
+      pending 'span_for_existing_event should include something for meta.package'
 
       expect(events.map(&:data)).to all(include beeline_meta_fields)
       expect(events.map(&:data)).to all(include 'meta.package')

--- a/spec/instrumented_apps/sinatra_activerecord/app_spec.rb
+++ b/spec/instrumented_apps/sinatra_activerecord/app_spec.rb
@@ -102,10 +102,7 @@ RSpec.describe SinatraActiveRecordApp do
     end
 
     it 'includes beeline meta fields in all the events' do
-      pending 'span_for_existing_event should include something for meta.package'
-
       expect(events.map(&:data)).to all(include beeline_meta_fields)
-      expect(events.map(&:data)).to all(include 'meta.package')
     end
 
     include_examples 'tracing'

--- a/spec/instrumented_apps/sinatra_sequel/app.rb
+++ b/spec/instrumented_apps/sinatra_sequel/app.rb
@@ -6,8 +6,9 @@ require 'honeycomb-beeline'
 require 'support/db_sequel'
 require 'support/fakehoney'
 require 'support/only_one_app'
+require 'support/test_logger'
 
-Honeycomb.init service_name: 'sinatra_sequel', client: $fakehoney
+Honeycomb.init service_name: 'sinatra_sequel', client: $fakehoney, logger: $test_logger
 
 class SinatraSequelApp < Sinatra::Base
   include ThereCanBeOnlyOneApp

--- a/spec/support/test_logger.rb
+++ b/spec/support/test_logger.rb
@@ -1,0 +1,8 @@
+require 'logger'
+
+$test_logger = Logger.new($stderr)
+if ENV['DEBUG']
+  $test_logger.level = Logger::DEBUG
+else
+  $test_logger.level = Logger::WARN
+end


### PR DESCRIPTION
![2018-10-22-214149_2273x400_scrot](https://user-images.githubusercontent.com/20528/47332021-a1c51200-d643-11e8-951b-6d4870cf73d0.png)

This cleans up the "secret" (although technically public) tracing API into something that should be reasonably usable by customers and we should be able to bless as a public API. It also adds support for encoding and decoding the trace context serialisation format specified [in the Node Beeline source](https://github.com/honeycombio/beeline-nodejs/blob/6fe61aafce61c8106a1c9dacbe2f99210e3698ae/lib/propagation.js#L12-L25).

With this PR, plus https://github.com/honeycombio/rack-honeycomb/pull/9, https://github.com/honeycombio/activerecord-honeycomb/pull/3 and https://github.com/honeycombio/faraday-honeycomb/pull/1, we can support cross-process tracing for Rails apps (e.g. the above screenshot shows a Rails app making an HTTP request to a Sinatra "auth" app).

The new API is (mostly) not backward-compatible with the old "secret" API, since that API was not mentioned anywhere in our prose docs and was marked in the Rubydocs with "This method is part of a private API". That said, we do know of at least one customer who was using it anyway, so we'll need to either reach out to anyone who was using it and help them migrate to the new API, or implement some backward-compatibility shims (which shouldn't be too difficult).

### Recommended steps to merge

The CI build for this PR will not currently pass because of the aforementioned backward-incompatibility: the released versions of the instrumentation gems depend on the old tracing API, detect that it's not present in the version of honeycomb-beeline being tested, and disable tracing. To get the tracing integration tests to pass, we need to merge and release the PRs for each instrumentation gem. So recommended steps to merge and release this:

 0. Note this is a "stacked" PR that depends on the changes in #3 - merge that PR before this one, and don't forget to change the "base branch" to master before merging.
 1. merge https://github.com/honeycombio/rack-honeycomb/pull/9 and publish a new release of rack-honeycomb (say, rack-honeycomb 0.4.0)
 2. merge https://github.com/honeycombio/activerecord-honeycomb/pull/3 and publish a new release of activerecord-honeycomb (say, activerecord-honeycomb 0.4.0)
 3. merge https://github.com/honeycombio/faraday-honeycomb/pull/1 and publish a new release of faraday-honeycomb (say, faraday-honeycomb 0.4.0)
 4. merge https://github.com/honeycombio/sequel-honeycomb/pull/1 and publish a new release of sequel-honeycomb (say, sequel-honeycomb 0.4.0)
 5. ask TravisCI to rerun the CI build for this PR - it will pull the newly released instrumentation gems and the tracing integration tests should pass.
 6. merge this PR.
 7. bump the [version requirements in honeycomb-beeline.gemspec](https://github.com/honeycombio/beeline-ruby/blob/master/honeycomb-beeline.gemspec#L24-L25) for activerecord-honeycomb, rack-honeycomb, sequel-honeycomb and faraday-honeycomb (e.g. to `'>= 0.4.0'`) so that the Beeline gem requires the newly released instrumentation gems.
 8. publish a new release of honeycomb-beeline.

Once that's done, anyone installing the Beeline (or updating an existing install) will get the cross-process-tracing-aware version of all five gems.

### Testing on a real app

If you want to try this out on an actual app before doing the above merge sequence, the easiest way will be to point the app at the relevant branches on Github. Add the following to the Rails app's `Gemfile` (replacing any existing `gem 'honeycomb-beeline'` line present):

```ruby
gem 'honeycomb-beeline', git: 'https://github.com/honeycombio/beeline-ruby', branch: 'sam.x-proc-trace'
gem 'rack-honeycomb', git: 'https://github.com/honeycombio/rack-honeycomb', branch: 'sam.x-proc-trace'
gem 'activerecord-honeycomb', git: 'https://github.com/honeycombio/activerecord-honeycomb', branch: 'sam.x-proc-trace'
gem 'faraday-honeycomb', git: 'https://github.com/honeycombio/faraday-honeycomb', branch: 'sam.x-proc-trace'
gem 'sequel-honeycomb', git: 'https://github.com/honeycombio/sequel-honeycomb', branch: 'sam.x-proc-trace'
```

Then run `bundle install` in the Rails app's root directory - Bundler will (behind the scenes) clone all three repos and check out the requested branches, so that when you run the Rails app it will use the branches instead of the released gems.