### PR TITLE
Use supported version of sinatra

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rails'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'sinatra'
+  gem.add_development_dependency 'sinatra', '<= 2.0.4'
   gem.add_development_dependency 'sequel'
   gem.add_development_dependency 'yard'
 


### PR DESCRIPTION
Latest version of sinatra breaks older ruby version compatibility