### PR TITLE
Remove default inclusion of Sequel instrumentation

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord-honeycomb', '>= 0.4.0'
   gem.add_dependency 'rack-honeycomb', '>= 0.4.0'
   gem.add_dependency 'faraday-honeycomb', '>= 0.3.0'
-  gem.add_dependency 'sequel-honeycomb', '>= 0.4.0'
 
 
   gem.add_development_dependency 'activerecord'

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sinatra', '<= 2.0.4'
   gem.add_development_dependency 'sequel'
+  gem.add_development_dependency 'sequel-honeycomb', '>= 0.4.0'
   gem.add_development_dependency 'yard'
 
 

--- a/lib/honeycomb/instrumentations.rb
+++ b/lib/honeycomb/instrumentations.rb
@@ -3,14 +3,12 @@ require 'honeycomb/client'
 require 'activerecord-honeycomb/auto_install'
 require 'faraday-honeycomb/auto_install'
 require 'rack-honeycomb/auto_install'
-require 'sequel-honeycomb/auto_install'
 
 module Honeycomb
   INSTRUMENTATIONS = [
     ActiveRecord::Honeycomb,
     Faraday::Honeycomb,
     Rack::Honeycomb,
-    Sequel::Honeycomb,
   ].freeze
 
   INSTRUMENTATIONS.each do |instrumentation|

--- a/spec/instrumented_apps/sinatra_sequel/app.rb
+++ b/spec/instrumented_apps/sinatra_sequel/app.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'sinatra/base'
 
 require 'honeycomb-beeline'
+require 'sequel-honeycomb/auto_install'
 
 require 'support/db_sequel'
 require 'support/fakehoney'
@@ -9,6 +10,7 @@ require 'support/only_one_app'
 require 'support/test_logger'
 
 Honeycomb.init service_name: 'sinatra_sequel', client: $fakehoney, logger: $test_logger
+Sequel::Honeycomb::AutoInstall.auto_install!(honeycomb_client: $fakehoney, logger: $test_logger)
 
 class SinatraSequelApp < Sinatra::Base
   include ThereCanBeOnlyOneApp


### PR DESCRIPTION
There is an issue with the way we have constructed the `Sequel` instrumentation that is problematic when included with applications that don't use `Sequel` but do have other gems that can support `Sequel`. 

In this scenario the other gems believe that `Sequel` is in use and attempt to configure themselves with `Sequel` which will fail as it is only present in the beeline.

This removes the default inclusion of the https://github.com/honeycombio/sequel-honeycomb gem which will fix the above issue. For people using the `Sequel` instrumentation there will be a couple of additional steps to take to instrument their `Sequel` calls. See the tests for an example of this