### PR TITLE
Allow calling #span without a block

### DIFF
--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -44,7 +44,7 @@ module Honeycomb
 
         start = Time.now
 
-        yield span_id, trace_id
+        yield span_id, trace_id if block_given?
       end
     rescue Exception => e
       if event


### PR DESCRIPTION
I'd like to add new event fields to a span without having to pass in an empty block:

`Honeycomb.span(type: 'worker', fields: some_hash) {}`

I didn't see anything in the readme regarding PR guidelines. This would be a nice-to-have but not an urgent change.