### PR TITLE
Remove `type = db` instrumentation

### DIFF
--- a/lib/honeycomb/instrumentations.rb
+++ b/lib/honeycomb/instrumentations.rb
@@ -1,12 +1,10 @@
 require 'honeycomb/client'
 
-require 'activerecord-honeycomb/auto_install'
 require 'faraday-honeycomb/auto_install'
 require 'rack-honeycomb/auto_install'
 
 module Honeycomb
   INSTRUMENTATIONS = [
-    ActiveRecord::Honeycomb,
     Faraday::Honeycomb,
     Rack::Honeycomb,
   ].freeze


### PR DESCRIPTION
## Summary
I'm removing `type=db` metrics because it created disproportionate numbers of event spans that we don't want. Here's the slack conversation for more context ([click](https://mode.slack.com/archives/C02JTGV79/p1560892625174400)).

## Follow up tasks

- Once this PR is wrapped up I'll give Honeycomb a headsup regarding this change ([click for slack convo](https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1561077520139500)).
- We'll need to update the reference for this fork in webapp's Gemfile

## Testing
I tested this change locally by running a report:

![Screen Shot 2019-07-03 at 11 52 49 AM](https://user-images.githubusercontent.com/4598088/60617903-978a1480-9d89-11e9-978c-43663c909591.png)