### PR TITLE
Update to test against rails6 rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ gemfile:
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_51.gemfile
   - gemfiles/rails_52.gemfile
-  - gemfiles/rails_6rc1.gemfile
+  - gemfiles/rails_6rc2.gemfile
 script: bundle exec rake test
 before_install:
   - gem update bundler
@@ -31,11 +31,11 @@ matrix:
     - rvm: 2.6
       gemfile: gemfiles/rails_41.gemfile
     - rvm: 2.2
-      gemfile: gemfiles/rails_6rc1.gemfile
+      gemfile: gemfiles/rails_6rc2.gemfile
     - rvm: 2.3
-      gemfile: gemfiles/rails_6rc1.gemfile
+      gemfile: gemfiles/rails_6rc2.gemfile
     - rvm: 2.4
-      gemfile: gemfiles/rails_6rc1.gemfile
+      gemfile: gemfiles/rails_6rc2.gemfile
 stages:
   - lint
   - test

--- a/Appraisals
+++ b/Appraisals
@@ -54,8 +54,8 @@ appraise "rails-52" do
   gem "warden"
 end
 
-appraise "rails-6rc1" do
+appraise "rails-6rc2" do
   gem "rack-test"
-  gem "rails", "6.0.0.rc1"
+  gem "rails", "6.0.0.rc2"
   gem "warden"
 end

--- a/gemfiles/rails_6rc2.gemfile
+++ b/gemfiles/rails_6rc2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rack-test"
-gem "rails", "6.0.0.rc1"
+gem "rails", "6.0.0.rc2"
 gem "warden"
 
 gemspec path: "../"


### PR DESCRIPTION
Rails6 rc2 has been released! Update our testing matrix to use rc2 instead of rc1.