### PR TITLE
Set sample hook on child spans

### DIFF
--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -51,7 +51,8 @@ module Honeycomb
       self.class.new(trace: trace,
                      builder: builder,
                      context: context,
-                     parent_id: id).tap do |c|
+                     parent_id: id,
+                     sample_hook: @sample_hook).tap do |c|
         children << c
       end
     end

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -52,7 +52,8 @@ module Honeycomb
                      builder: builder,
                      context: context,
                      parent_id: id,
-                     sample_hook: @sample_hook).tap do |c|
+                     sample_hook: sample_hook,
+                     presend_hook: presend_hook).tap do |c|
         children << c
       end
     end

--- a/spec/honeycomb/span_spec.rb
+++ b/spec/honeycomb/span_spec.rb
@@ -51,14 +51,28 @@ RSpec.describe Honeycomb::Span do
   end
 
   describe "when a span creates a child span" do
+    let(:presend_hook) { double("PresendHook") }
     let(:sample_hook) { double("SampleHook") }
 
     before do
-      allow(sample_hook).to receive(:call)
+      allow(presend_hook).to receive(:call)
+      # we have to configure the sample_hook here to return the expected value
+      # as the presend_hook will not be called if the event is not going to be
+      # sent
+      allow(sample_hook).to receive(:call).and_return([true, 0])
     end
 
     it "sets the sample_hook on the child" do
       expect(sample_hook).to receive(:call)
+        .with(hash_including("honeycomb" => "bees"))
+
+      child = span.create_child
+      child.add_field("honeycomb", "bees")
+      child.send
+    end
+
+    it "sets the presend_hook on the child" do
+      expect(presend_hook).to receive(:call)
         .with(hash_including("honeycomb" => "bees"))
 
       child = span.create_child

--- a/spec/honeycomb/span_spec.rb
+++ b/spec/honeycomb/span_spec.rb
@@ -51,10 +51,19 @@ RSpec.describe Honeycomb::Span do
   end
 
   describe "when a span creates a child span" do
-    it "sets the sample_hook on the child" do
-      child = span.create_child
+    let(:sample_hook) { double("SampleHook") }
 
-      expect(child.sample_hook).to eq sample_hook
+    before do
+      allow(sample_hook).to receive(:call)
+    end
+
+    it "sets the sample_hook on the child" do
+      expect(sample_hook).to receive(:call)
+        .with(hash_including("honeycomb" => "bees"))
+
+      child = span.create_child
+      child.add_field("honeycomb", "bees")
+      child.send
     end
   end
 

--- a/spec/honeycomb/span_spec.rb
+++ b/spec/honeycomb/span_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Honeycomb::Span do
     end
   end
 
+  describe "when a span creates a child span" do
+    it "sets the sample_hook on the child" do
+      child = span.create_child
+
+      expect(child.sample_hook).to eq sample_hook
+    end
+  end
+
   describe "when the sampling hook returns true" do
     let(:presend_hook) { double("PresendHook") }
     let(:sampling_decision) { true }


### PR DESCRIPTION
I have an application which has a health check endpoint, which I'd like to filter out from Honeycomb. The endpoint gets a lot of requests and they aren't particularly interesting to log.

While trying to set a sample_hook, I noticed that child spans created by the ActiveSupport subscriber integration aren't being filtered out. Since every request to this healthcheck endpoint was generating a child span via ActionController, the sample hook was only able to filter out half of the spans. 

This PR sets the `sample_hook` parameter when creating child spans, so that any span can potentially be filtered out.

Let me know if there's a better way to accomplish this. I noticed that [`send_children`](https://github.com/honeycombio/beeline-ruby/blob/master/lib/honeycomb/span.rb#L101) is called in `span.rb` before testing whether the span should be sampled. So it looks like another approach would be to move that call to a little later in the `send_internal` method.