### PR TITLE
Split rails and railtie integrations

### DIFF
--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -13,6 +13,7 @@ module Honeycomb
     faraday
     rack
     rails
+    railtie
     rake
     sequel
     sinatra

--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -35,11 +35,19 @@ module Honeycomb
     end
 
     def load_integrations
-      INTEGRATIONS.each do |integration|
+      intergations_to_load.each do |integration|
         begin
           require "honeycomb/integrations/#{integration}"
         rescue LoadError
         end
+      end
+    end
+
+    def intergations_to_load
+      if ENV["HONEYCOMB_INTEGRATIONS"]
+        ENV["HONEYCOMB_INTEGRATIONS"].split(",")
+      else
+        INTEGRATIONS
       end
     end
   end

--- a/lib/honeycomb/integrations/rails.rb
+++ b/lib/honeycomb/integrations/rails.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rails/railtie"
 require "honeycomb/integrations/active_support"
 require "honeycomb/integrations/rack"
 require "honeycomb/integrations/warden"
@@ -34,21 +33,6 @@ module Honeycomb
       include Rack
       include Warden
       include Rails
-    end
-  end
-
-  # Automatically capture rack requests and create a trace
-  class Railtie < ::Rails::Railtie
-    initializer("honeycomb.install_middleware",
-                after: :load_config_initializers) do |app|
-      if Honeycomb.client
-        # what location should we insert the middleware at?
-        app.config.middleware.insert_before(
-          ::Rails::Rack::Logger,
-          Honeycomb::Rails::Middleware,
-          client: Honeycomb.client,
-        )
-      end
     end
   end
 end

--- a/lib/honeycomb/integrations/railtie.rb
+++ b/lib/honeycomb/integrations/railtie.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+require "honeycomb/integrations/rails"
+
+module Honeycomb
+  # Automatically capture rack requests and create a trace
+  class Railtie < ::Rails::Railtie
+    initializer("honeycomb.install_middleware",
+                after: :load_config_initializers) do |app|
+      if Honeycomb.client
+        # what location should we insert the middleware at?
+        app.config.middleware.insert_before(
+          ::Rails::Rack::Logger,
+          Honeycomb::Rails::Middleware,
+          client: Honeycomb.client,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Splits up the rails and railtie integrations so that people can skip loading the railtie if they want more control over where the middleware is added in the stack.

@sethjohnson-flexe this should allow you to run your app without the railtie being loaded so that you can add the middleware in a suitable location. How do you feel about this solution?

It would look something like the below, you would then need to add the middleware manually in a location that works with your application.

`HONEYCOMB_INTEGRATIONS=rails,faraday bundle exec rails server`