### PR TITLE
Skip params when unavailable

### DIFF
--- a/lib/honeycomb/integrations/rails.rb
+++ b/lib/honeycomb/integrations/rails.rb
@@ -13,6 +13,9 @@ module Honeycomb
 
       ::ActionDispatch::Request.new(env).tap do |request|
         # calling request.params will blow up if raw_post is nil
+        # the only known cause of this is when using the
+        # [twirp](https://github.com/twitchtv/twirp-ruby) rack app mounted in
+        # the rails app
         if request.raw_post
           yield "request.controller", request.params[:controller]
           yield "request.action", request.params[:action]

--- a/lib/honeycomb/integrations/rails.rb
+++ b/lib/honeycomb/integrations/rails.rb
@@ -12,8 +12,11 @@ module Honeycomb
       yield "meta.package_version", ::Rails::VERSION::STRING
 
       ::ActionDispatch::Request.new(env).tap do |request|
-        yield "request.controller", request.params[:controller]
-        yield "request.action", request.params[:action]
+        # calling request.params will blow up if raw_post is nil
+        if request.raw_post
+          yield "request.controller", request.params[:controller]
+          yield "request.action", request.params[:action]
+        end
 
         break unless request.respond_to? :routes
         break unless request.routes.respond_to? :router


### PR DESCRIPTION
Fixes https://github.com/honeycombio/beeline-ruby/issues/31.

Tracing this through, we call this [method](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/parameters.rb#L50) and `action_dispatch.request.parameters` is nil. So we fall into this [method](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L381) which eventually ends up calling this [lambda](https://github.com/rails/rails/blob/a3d54d2afe557b243d6b18f9adf119f60ffb8242/actionpack/lib/action_dispatch/http/parameters.rb#L11) which raises an error when `raw_post` is nil. 

I'm not entirely clear what [twirp](https://github.com/twitchtv/twirp-ruby) is doing to the request to end up in this state and have struggled to reproduce this in a test. This should prevent the issue though and doesn't seem to cause any other side effects that I could find.