### PR TITLE
Parameterize the namespace in Honeycomb.add_field{,_to_trace}

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -64,16 +64,18 @@ module Honeycomb
       end
     end
 
-    def add_field(key, value)
+    def add_field(key, value, namespace: "app")
       return if context.current_span.nil?
 
-      context.current_span.add_field("app.#{key}", value)
+      key = "#{namespace}.#{key}" if namespace
+      context.current_span.add_field(key, value)
     end
 
-    def add_field_to_trace(key, value)
+    def add_field_to_trace(key, value, namespace: "app")
       return if context.current_span.nil?
 
-      context.current_span.trace.add_field("app.#{key}", value)
+      key = "#{namespace}.#{key}" if namespace
+      context.current_span.trace.add_field(key, value)
     end
 
     private

--- a/spec/honeycomb/beeline_spec.rb
+++ b/spec/honeycomb/beeline_spec.rb
@@ -40,12 +40,18 @@ RSpec.describe Honeycomb do
     before do
       Honeycomb.start_span(name: "test") do
         Honeycomb.add_field("interesting", "banana")
+        Honeycomb.add_field("fascinating", "apple", namespace: "hmm")
+        Honeycomb.add_field("captivating", "orange", namespace: nil)
       end
     end
 
-    it "contains the expected field" do
-      expect(libhoney_client.events.map(&:data))
-        .to all(include("app.interesting" => "banana"))
+    it "contains the expected fields" do
+      fields = {
+        "app.interesting" => "banana",
+        "hmm.fascinating" => "apple",
+        "captivating" => "orange",
+      }
+      expect(libhoney_client.events.map(&:data)).to all(include(fields))
     end
   end
 
@@ -53,12 +59,18 @@ RSpec.describe Honeycomb do
     before do
       Honeycomb.start_span(name: "test") do
         Honeycomb.add_field_to_trace("interesting", "banana")
+        Honeycomb.add_field_to_trace("fascinating", "apple", namespace: "hmm")
+        Honeycomb.add_field_to_trace("captivating", "orange", namespace: nil)
       end
     end
 
-    it "contains the expected field" do
-      expect(libhoney_client.events.map(&:data))
-        .to all(include("app.interesting" => "banana"))
+    it "contains the expected fields" do
+      fields = {
+        "app.interesting" => "banana",
+        "hmm.fascinating" => "apple",
+        "captivating" => "orange",
+      }
+      expect(libhoney_client.events.map(&:data)).to all(include(fields))
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, the only way to avoid the `app` namespace was to
use the block form of `Honeycomb.start_span`. However, in more complex
code, it's not always feasible or convenient to use the block form. I
found myself bending over backwards to try to avoid the `app` namespace:
passing around the `Honeycomb::Span` between separate objects, having to
maintain a stack due to span nesting, realizing I was reinventing
`Honeycomb::Context`, falling back to the "dirty" way of reaching into
private attributes (i.e., `Honeycomb.client.send(:context)`), and so on.
It was a mess.

There were two ways I can think of to solve this issue:

1. Expose `Honeycomb::Context#current_span` via the `Honeycomb` module:

    ```ruby
    Honeycomb.current_span.add_field("my.namespace.field", "value")
    ```

2. Parameterize the namespace in existing methods:

    ```ruby
    Honeycomb.add_field("field", "value", namespace: "my.namespace")
    ```

The first way seems like the most general. By exposing the
`Honeycomb::Span` object directly, you basically get all the benefits of
using the block form. However, the big issue with accessing the span
directly compared to using the field-adder methods is that it isn't
nil-safe. Depending on Ruby version, you'd have to write your code like

```ruby
Honeycomb.span&.add(fields)
```

or

```ruby
Honeycomb.span.add(fields) if Honeycomb.span
```

To me, the extra complexity kind of defeats the purpose of having the
shorthand module methods in the first place. It requires too much
thinking to acknowledge that the span might be nil (which isn't a
problem in the block form either, by the way, since of course
`Honeycomb.start_span` has started a span). This could be addressed by
the null object pattern, but it all starts to feel like yak shaving.

So ultimately, this commit implements the second solution. It's the
least amount of change to get the desired effect. It doesn't really
increase the footprint of the API, since it only solves for the specific
problem of namespacing. It's still backwards-compatible, since `app` is
being used as the default namespace. And it's still totally nil-safe.

I'd still be in favor of the first solution from a generality
perspective, but it's just a more significant design change. While this
commit still doesn't give *total* access to the same `Honeycomb::Span`
functionality (e.g., `Honeycomb::Span#to_trace_header`), we have still
have probably the most important pieces - the shorthand field-adder
methods. Only now, it's easier to circumvent the namespacing.