### PR TITLE
Expose context methods for current trace and span

### DIFF
--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -25,7 +25,8 @@ module Honeycomb
     extend Forwardable
     attr_reader :client
 
-    def_delegators :@client, :start_span, :add_field, :add_field_to_trace
+    def_delegators :@client, :start_span, :add_field, :add_field_to_trace,
+                   :current_span, :current_trace
 
     def configure
       Configuration.new.tap do |config|

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "forwardable"
 require "honeycomb/beeline/version"
 require "honeycomb/configuration"
 require "honeycomb/context"
@@ -7,6 +8,10 @@ require "honeycomb/context"
 module Honeycomb
   # The Honeycomb Beeline client
   class Client
+    extend Forwardable
+
+    def_delegators :@context, :current_span, :current_trace
+
     def initialize(configuration:)
       @client = configuration.client
       # attempt to set the user_agent_addition, this will only work if the

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -11,7 +11,6 @@ module Honeycomb
     extend Forwardable
 
     def_delegators :@context, :current_span, :current_trace
-    def_delegators :@client, :dataset, :service_name
 
     def initialize(configuration:)
       @client = configuration.client
@@ -80,10 +79,6 @@ module Honeycomb
       return if context.current_span.nil?
 
       context.current_span.trace.add_field("app.#{key}", value)
-    end
-
-    def debug?
-      client.debug ? true : false
     end
 
     private

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -11,6 +11,7 @@ module Honeycomb
     extend Forwardable
 
     def_delegators :@context, :current_span, :current_trace
+    def_delegators :@client, :dataset, :service_name
 
     def initialize(configuration:)
       @client = configuration.client
@@ -79,6 +80,10 @@ module Honeycomb
       return if context.current_span.nil?
 
       context.current_span.trace.add_field("app.#{key}", value)
+    end
+
+    def debug?
+      client.debug ? true : false
     end
 
     private


### PR DESCRIPTION
Expose the current trace and current span in the top level scope. These properties are useful for doing custom instrumentation.