### PR TITLE
Try inserting middleware after ActionDispatch::ShowExceptions

### DIFF
--- a/lib/honeycomb/integrations/railtie.rb
+++ b/lib/honeycomb/integrations/railtie.rb
@@ -9,12 +9,19 @@ module Honeycomb
     initializer("honeycomb.install_middleware",
                 after: :load_config_initializers) do |app|
       if Honeycomb.client
-        # what location should we insert the middleware at?
-        app.config.middleware.insert_before(
-          ::Rails::Rack::Logger,
-          Honeycomb::Rails::Middleware,
-          client: Honeycomb.client,
-        )
+        if defined? ActionDispatch::ShowExceptions
+          app.config.middleware.insert_after(
+            ActionDispatch::ShowExceptions,
+            Honeycomb::Rails::Middleware,
+            client: Honeycomb.client,
+          )
+        else
+          app.config.middleware.insert_before(
+            ::Rails::Rack::Logger,
+            Honeycomb::Rails::Middleware,
+            client: Honeycomb.client,
+          )
+        end
       end
     end
   end

--- a/lib/honeycomb/integrations/railtie.rb
+++ b/lib/honeycomb/integrations/railtie.rb
@@ -9,19 +9,11 @@ module Honeycomb
     initializer("honeycomb.install_middleware",
                 after: :load_config_initializers) do |app|
       if Honeycomb.client
-        if defined? ActionDispatch::ShowExceptions
-          app.config.middleware.insert_after(
-            ActionDispatch::ShowExceptions,
-            Honeycomb::Rails::Middleware,
-            client: Honeycomb.client,
-          )
-        else
-          app.config.middleware.insert_before(
-            ::Rails::Rack::Logger,
-            Honeycomb::Rails::Middleware,
-            client: Honeycomb.client,
-          )
-        end
+        app.config.middleware.insert_after(
+          ActionDispatch::ShowExceptions,
+          Honeycomb::Rails::Middleware,
+          client: Honeycomb.client,
+        )
       end
     end
   end


### PR DESCRIPTION
Hi there! 👋 

We've recently started trying out the Honeycomb service in our Rails apps. Our apps get fuzzed a lot by security researchers via our HackerOne program, which means we have to deal with a lot of garbage input from scripts looking for vulnerabilities.

When we receive requests with invalid parameter encodings, the `beeline-ruby` gem will produce 500 error responses from the server due to its insertion point in the Rails middleware stack. You can confirm this by visiting `localhost:3000?via=%c1` in a vanilla Rails app with this gem installed. Here's a lightly redacted backtrace from one of our apps:

```
[2019-12-09 10:33:37] ERROR ActionController::BadRequest: Invalid query parameters: Invalid encoding for parameter: �
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/request/utils.rb:39:in `check_param_encoding'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/request/utils.rb:34:in `block in check_param_encoding'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/request/utils.rb:34:in `each_value'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/request/utils.rb:34:in `check_param_encoding'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/http/request.rb:370:in `block in GET'
[REDACTED]/rack-2.0.7/lib/rack/request.rb:59:in `fetch'
[REDACTED]/rack-2.0.7/lib/rack/request.rb:59:in `fetch_header'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/http/request.rb:367:in `GET'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/http/parameters.rb:55:in `parameters'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/integrations/rails.rb:21:in `block in add_package_information'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/integrations/rails.rb:14:in `tap'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/integrations/rails.rb:14:in `add_package_information'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/integrations/rack.rb:40:in `block in call'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/client.rb:54:in `start_span'
[REDACTED]/honeycomb-beeline-1.1.1/lib/honeycomb/integrations/rack.rb:29:in `call'
[REDACTED]/sprockets-rails-3.2.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/middleware/request_id.rb:27:in `call'
[REDACTED]/rack-2.0.7/lib/rack/method_override.rb:22:in `call'
[REDACTED]/rack-2.0.7/lib/rack/runtime.rb:22:in `call'
[REDACTED]/activesupport-5.2.3/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/middleware/executor.rb:14:in `call'
[REDACTED]/actionpack-5.2.3/lib/action_dispatch/middleware/static.rb:127:in `call'
[REDACTED]/rack-2.0.7/lib/rack/sendfile.rb:111:in `call'
[REDACTED]/rack-attack-5.0.1/lib/rack/attack.rb:147:in `call'
[REDACTED]/railties-5.2.3/lib/rails/engine.rb:524:in `call'
[REDACTED]/rack-2.0.7/lib/rack/handler/webrick.rb:86:in `service'
```

## Why does the middleware insertion point matter?

Rails has a default middleware called [`ActionDispatch::ShowExceptions`](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/show_exceptions.rb). As documented:

> This middleware rescues any exception returned by the application
> and calls an exceptions app that will wrap it in a format for the end user.

As part of that exception handling, it [instantiates](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L45) an [`ActionDispatch::ExceptionWrapper`](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb). This wrapper filters for all sorts of errors, including, crucially for this issue, [`ActionController::BadRequest`](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L20). It will then utilize [`ActionDispatch::PublicExceptions`](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/public_exceptions.rb) as the default exception handler (instance of [`@exceptions_app`](https://github.com/rails/rails/blob/758e4f8406e680a6cbf21b170749202c537a2576/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L50)), to return a 400 response to the client.

Currently, in the `beeline-ruby` gem, the call to [`request.params`](https://github.com/honeycombio/beeline-ruby/blob/0285e1881711e416e579861240eb93595821cbaf/lib/honeycomb/integrations/rails.rb#L20) triggers the error with invalid parameter encodings. If we insert `Honeycomb::Rails::Middleware` after `ActionDispatch::ShowExceptions`, it allows this default 400 response mechanism to take effect. Without moving the middleware, we're required to inject more middleware above `Honeycomb::Rails::Middleware` that re-implements Rails' existing behavior for catching these errors and returning 400s.

I've seen in the repo history that issues have arisen before with the middleware insertion. I also found for https://github.com/honeycombio/beeline-ruby/issues/32 that you [introduced the `HONEYCOMB_INTEGRATIONS`](https://github.com/honeycombio/beeline-ruby/pull/35/files#diff-4fb04c3c72efcd805e6fbf62dd79e4efR47) ENV var to allow for disabling the default middleware loading, which requires us to then load it ourselves beneath `ActionDispatch::ShowExceptions`, but this seems to me to be a rather cumbersome workaround for us to re-enable this feature of Rails.

This PR attempts to move the Honeycomb middleware beneath `ActionDispatch::ShowExceptions`, which is just two middleware spots lower than it currently resides on a default Rails 6 app. Here's the full list of default middleware on a newly generated Rails app:

```
$ rails -v
Rails 6.0.1

$ RAILS_ENV=production rails middleware
use ActionDispatch::HostAuthorization
use Rack::Sendfile
use ActionDispatch::Executor
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use ActionDispatch::ActionableExceptions
use ActionDispatch::Callbacks
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
use ActionDispatch::Flash
use ActionDispatch::ContentSecurityPolicy::Middleware
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
use Rack::TempfileReaper
run Mid::Application.routes
```

What do y'all think about moving this down? (Also, I'd have no objections to editing the PR to remove the conditional and just subbing out `ActionDispatch::ShowExceptions` for `::Rails::Rack::Logger`, but that felt overly presumptuous.) Thanks for your time and consideration!