### PR TITLE
Handle bad request params

### DIFF
--- a/lib/honeycomb/integrations/rails.rb
+++ b/lib/honeycomb/integrations/rails.rb
@@ -17,8 +17,13 @@ module Honeycomb
         # [twirp](https://github.com/twitchtv/twirp-ruby) rack app mounted in
         # the rails app
         if request.raw_post
-          yield "request.controller", request.params[:controller]
-          yield "request.action", request.params[:action]
+          begin
+            yield "request.controller", request.params[:controller]
+            yield "request.action", request.params[:action]
+          rescue ::ActionController::BadRequest => e
+            yield "request.controller", e.message
+            yield "request.action", e.message
+          end
         end
 
         break unless request.respond_to? :routes

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -66,5 +66,26 @@ if defined?(Honeycomb::Rails)
 
       it_behaves_like "event data"
     end
+
+    describe "a bad request" do
+      before do
+        header("Http-Version", "HTTP/1.0")
+        header("User-Agent", "RackSpec")
+
+        get "/hello/martin?via=%c1"
+      end
+
+      it "returns bad request" do
+        expect(last_response).to be_bad_request
+      end
+
+      it "sends the right number of events" do
+        expect(libhoney_client.events.size).to eq 1
+      end
+
+      let(:event_data) { libhoney_client.events.map(&:data) }
+
+      it_behaves_like "event data"
+    end
   end
 end

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -46,23 +46,25 @@ if defined?(Honeycomb::Rails)
       end
     end
 
-    before do
-      header("Http-Version", "HTTP/1.0")
-      header("User-Agent", "RackSpec")
+    describe "a standard request" do
+      before do
+        header("Http-Version", "HTTP/1.0")
+        header("User-Agent", "RackSpec")
 
-      get "/hello/martin"
+        get "/hello/martin"
+      end
+
+      it "returns ok" do
+        expect(last_response).to be_ok
+      end
+
+      it "sends the right number of events" do
+        expect(libhoney_client.events.size).to eq 3
+      end
+
+      let(:event_data) { libhoney_client.events.map(&:data) }
+
+      it_behaves_like "event data"
     end
-
-    it "returns ok" do
-      expect(last_response).to be_ok
-    end
-
-    it "sends the right number of events" do
-      expect(libhoney_client.events.size).to eq 3
-    end
-
-    let(:event_data) { libhoney_client.events.map(&:data) }
-
-    it_behaves_like "event data"
   end
 end


### PR DESCRIPTION
As mentioned in #49, the rails middleware can break when there are bad params sent to the rails application and it tries to read out the controller and action. 

In this we catch the bad request exception and set the message as the value for controller and action. I'm not sure if this super useful though. A sample of this is below. Anyone have any thoughts? We could also just not add those keys at all or set them to 'unknown' or similar?

```
"request.action"=>"Invalid query parameters: Invalid encoding for parameter: �"
```