### PR TITLE
Add Honeycomb.{with_field,with_trace_field}

### DIFF
--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -25,7 +25,12 @@ module Honeycomb
     extend Forwardable
     attr_reader :client
 
-    def_delegators :@client, :start_span, :add_field, :add_field_to_trace
+    def_delegators :@client,
+                   :start_span,
+                   :add_field,
+                   :add_field_to_trace,
+                   :with_field,
+                   :with_trace_field
 
     def configure
       Configuration.new.tap do |config|

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -76,6 +76,14 @@ module Honeycomb
       context.current_span.trace.add_field("app.#{key}", value)
     end
 
+    def with_field(key)
+      yield.tap { |value| add_field(key, value) }
+    end
+
+    def with_trace_field(key)
+      yield.tap { |value| add_field_to_trace(key, value) }
+    end
+
     private
 
     attr_reader :client, :context

--- a/spec/honeycomb/beeline_spec.rb
+++ b/spec/honeycomb/beeline_spec.rb
@@ -61,6 +61,46 @@ RSpec.describe Honeycomb do
         .to all(include("app.interesting" => "banana"))
     end
   end
+
+  describe "adding computed fields to span" do
+    let(:field) do
+      Honeycomb.start_span(name: "test") do
+        Honeycomb.with_field("interesting") do
+          "banana"
+        end
+      end
+    end
+
+    it "returns the field's value" do
+      expect(field).to eq "banana"
+    end
+
+    it "contains the expected field" do
+      field # send the events
+      expect(libhoney_client.events.map(&:data))
+        .to all(include("app.interesting" => "banana"))
+    end
+  end
+
+  describe "adding computed fields to trace" do
+    let(:field) do
+      Honeycomb.start_span(name: "test") do
+        Honeycomb.with_trace_field("interesting") do
+          "banana"
+        end
+      end
+    end
+
+    it "returns the field's value" do
+      expect(field).to eq "banana"
+    end
+
+    it "contains the expected field" do
+      field # send the events
+      expect(libhoney_client.events.map(&:data))
+        .to all(include("app.interesting" => "banana"))
+    end
+  end
 end
 
 RSpec.describe Honeycomb::Beeline do


### PR DESCRIPTION
The return value of `Honeycomb.add_field` (and similarly
`Honeycomb.add_field_to_trace`) is the `Libhoney::Event` object that had
the field added.

However, I'd often have the pattern in my code of using

```ruby
def something
  (some || sort && of ** expression).tap do |value|
    Honeycomb.add_field('field', value)
  end
end
```

That is, I still want the return value of the `#something` method, but I
wanted to track its value in a Honeycomb field. The methods added in
this commit allow the more natural pattern of wrapping the computation
in a block like so:

```ruby
def something
  Honeycomb.with_field('field') do
    some || sort && of ** expression
  end
end
```

It's just a minor feature, but one that would make some of my code a
little nicer looking. Especially with predicates, where I currently have
code like `question?.tap { ... }`.