### PR TITLE
Add a contributed redis benchmark for easier repro

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 .idea/
+vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in honeycomb-beeline.gemspec
 gemspec
+
+group :benchmark do
+  gem 'benchmark'
+  gem 'connection_pool'
+  gem 'ulid'
+  gem 'redis'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :benchmark do
-  gem 'benchmark'
-  gem 'connection_pool'
-  gem 'ulid'
-  gem 'redis'
+  gem "benchmark"
+  gem "connection_pool"
+  gem "redis"
+  gem "ulid"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
+    benchmark (0.1.0)
     bump (0.8.0)
     byebug (11.0.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -63,6 +65,7 @@ GEM
     public_suffix (3.1.1)
     rainbow (3.0.0)
     rake (12.3.2)
+    redis (4.1.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -99,6 +102,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
+    ulid (1.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -113,18 +117,22 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  benchmark
   bump
   bundler
+  connection_pool
   honeycomb-beeline!
   overcommit (~> 0.46.0)
   pry-byebug
   rake
+  redis
   rspec (~> 3.0)
   rubocop (< 0.69)
   rubocop-performance (< 1.3.0)
   simplecov
   simplecov-console
+  ulid
   webmock
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/bin/benchmark-redis.rb
+++ b/bin/benchmark-redis.rb
@@ -27,7 +27,9 @@ def redistest
 
     data = [].tap { |a| rand(50).times { a.append(ULID.generate) } }.join " "
     key = ULID.generate
-    redispool = ConnectionPool.new(size: 5) { ::Redis.new(url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }) }
+    redispool = ConnectionPool.new(size: 5) do
+      ::Redis.new(url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" })
+    end
     redispool.with do |redis|
       redis.set(key, data)
       redis.expire(key, 60)

--- a/bin/benchmark-redis.rb
+++ b/bin/benchmark-redis.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "benchmark"
+require "ulid"
+require "connection_pool"
+require "redis"
+
+API_KEY = ENV.fetch("HCKEY")
+if API_KEY == ""
+  puts "Missing API key in ENV[HCKEY]"
+  exit 1
+end
+
+DATASET = ENV.fetch("HCDATASET")
+if DATASET == ""
+  puts "Missing dataset name in ENV[DATASET]"
+  exit 1
+end
+
+NUMBER = 1000
+
+def redistest
+  index = 0
+  while index < NUMBER
+    index += 1
+
+    data = [].tap { |a| rand(50).times { a.append(ULID.generate) } }.join " "
+    key = ULID.generate
+    redispool = ConnectionPool.new(size: 5) { ::Redis.new(url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }) }
+    redispool.with do |redis|
+      redis.set(key, data)
+      redis.expire(key, 60)
+
+      redis.get(key)
+      redis.del(key)
+    end
+  end
+end
+
+def hcrequied
+  require "honeycomb-beeline"
+  redistest
+end
+
+def hctestclient
+  require "honeycomb-beeline"
+  Honeycomb.configure do |config|
+    config.client = Libhoney::TestClient.new
+  end
+  redistest
+end
+
+def hcprodclient
+  require "honeycomb-beeline"
+  Honeycomb.configure do |config|
+    config.write_key = API_KEY
+    config.dataset = DATASET
+  end
+  redistest
+end
+
+Benchmark.bm(20) do |x|
+  x.report("plain redis:") { redistest }
+  x.report("plain redis2:") { redistest }
+  require "honeycomb-beeline"
+  x.report("hc required:") { hcrequied }
+  x.report("hc test client:") { hctestclient }
+  x.report("hc prod client:") { hcprodclient }
+end


### PR DESCRIPTION
Taking the redis benchmark contributed in #57 (thanks directionless!) and adding it to the repo for eventual inclusion into circleCI tests.   

also: clean up a tiny thing about how we were using bundler (no config file, vendor dir wasn't in gitignore)

```
# spin up a redis 5 instance in docker:
$ docker run --name redis-benchmark --rm -p 6379:6379 -d redis

# run1:
$ bundle exec bin/redis-benchmarks.rb
                           user     system      total        real
plain redis:           0.771792   0.243165   1.014957 (  1.465325)
hc required:           0.503528   0.134255   0.637783 (  0.834873)
hc test client:        1.272352   0.182356   1.454708 (  1.761655)
hc prod client:        3.029869   0.723596   3.753465 (  3.410702)

# run2:
$ bundle exec bin/redis-benchmarks.rb
                           user     system      total        real
plain redis:           0.680019   0.182846   0.862865 (  1.192515)
hc required:           0.481824   0.169231   0.651055 (  0.857399)
hc test client:        1.292129   0.145744   1.437873 (  1.732268)
hc prod client:        2.727334   0.619321   3.346655 (  3.052735)
```

Signed-off-by: Irving Popovetsky <irving@honeycomb.io>