### PR TITLE
Fix `Redis.honeycomb_client = nil`

### DIFF
--- a/lib/honeycomb/integrations/redis.rb
+++ b/lib/honeycomb/integrations/redis.rb
@@ -23,7 +23,9 @@ module Honeycomb
       attr_writer :honeycomb_client
 
       def honeycomb_client
-        @honeycomb_client || Honeycomb.client
+        return @honeycomb_client if defined?(@honeycomb_client)
+
+        Honeycomb.client
       end
     end
 

--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -61,7 +61,8 @@ if defined?(Honeycomb::Redis)
     end
 
     shared_examples "the redis span" do |redis_command|
-      it "can be disabled" do
+      it "can be disabled (even if Honeycomb is globally configured)" do
+        Honeycomb.configure { |config| config.client = libhoney_client }
         Redis.honeycomb_client = nil
         command
         expect(libhoney_client.events).to be_empty


### PR DESCRIPTION
The idea of this attribute was that you'd be able to turn off the Redis
instrumentation by blanking out the Honeycomb client.

However, by using `||`, the code was *actually* falling back to the
global `Honeycomb.client` whenever we set `Redis.honeycomb_client =
nil`. The spec was passing erroneously because it was being run in a
context where `Honeycomb.client` was *also* `nil`. Oops!

By switching this to use the `defined?` check, we'll return `nil` from
`Redis.honeycomb_client` as long as it's been explicitly blanked out by
the user.