### PR TITLE
Fix bad request based key names

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -58,8 +58,8 @@ module Honeycomb
         begin
           yield context.current_span
         rescue StandardError => e
-          context.current_span.add_field("request.error", e.class.name)
-          context.current_span.add_field("request.error_detail", e.message)
+          context.current_span.add_field("error", e.class.name)
+          context.current_span.add_field("error_detail", e.message)
           raise e
         ensure
           context.current_span.send

--- a/spec/honeycomb/client_spec.rb
+++ b/spec/honeycomb/client_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Honeycomb::Client do
 
     it_behaves_like "event data",
                     package_fields: false,
-                    additional_fields: ["request.error", "request.error_detail"]
+                    additional_fields: %w[error error_detail]
   end
 
   describe "can add field to trace" do


### PR DESCRIPTION
These mistakenly have 'request' in them when it can be used in a non
request context. It also better matches the other beelines.