### PR TITLE
Handle Missing Span Timestamps To Prevent TypeError

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 * Sergio Mira
 * Alex Vondrak - [@ajvondrak](https://github.com/ajvondrak)
+* Molly Struve - [@mstruve](https://github.com/mstruve)

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -123,7 +123,9 @@ module Honeycomb
     end
 
     def duration_ms
-      (clock_time - @started) * 1000
+      current_time = clock_time
+      return 0 unless @started && current_time
+      (current_time - @started) * 1000
     end
 
     def clock_time

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -125,7 +125,7 @@ module Honeycomb
     def duration_ms
       current_time = clock_time
       return 0 unless @started && current_time
-      
+
       (current_time - @started) * 1000
     end
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -125,6 +125,7 @@ module Honeycomb
     def duration_ms
       current_time = clock_time
       return 0 unless @started && current_time
+      
       (current_time - @started) * 1000
     end
 


### PR DESCRIPTION
Hi there! 

[We](https://github.com/thepracticaldev/dev.to) have been getting a few Honeybadgers recently with the following error
```
TypeError: nil can't be coerced into Float
span.rb  126 -(...)
[GEM_ROOT]/gems/honeycomb-beeline-1.3.0/lib/honeycomb/span.rb:126:in `-'
124 
125     def duration_ms
126       (clock_time - @started) * 1000
127     end
```
Example Honeybadgers:
https://app.honeybadger.io/fault/66984/fc5385f35bb6c7ac7b980fa8a0ed4ba2
https://app.honeybadger.io/fault/66984/cdef171085da40ad5a0e99df87c6fdca

I am not sure what is directly the cause of the missing timestamps but I thought it might be prudent to handle their nil case seeing as it is not uncommon. I choose to return 0 since that seemed like it would not break anything, yet would indicate the duration is not valid. I could also see a value of -1 possibly being returned.

Let me know what you think! This is causing a bit of noise in our error reporting which is why I want to try and help clean it up. Thanks!