### PR TITLE
Make the libhoney client instance accessible.

### DIFF
--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -25,8 +25,8 @@ module Honeycomb
     extend Forwardable
     attr_reader :client
 
-    def_delegators :@client, :start_span, :add_field, :add_field_to_trace,
-                   :current_span, :current_trace
+    def_delegators :@client, :libhoney, :start_span, :add_field,
+                   :add_field_to_trace, :current_span, :current_trace
 
     def configure
       Configuration.new.tap do |config|

--- a/spec/honeycomb/beeline_spec.rb
+++ b/spec/honeycomb/beeline_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Honeycomb do
     end
   end
 
+  describe "accessing the libhoney instance" do
+    it "contains the expected field" do
+      expect(Honeycomb.libhoney).to eq libhoney_client
+    end
+  end
+
   describe "when using a block" do
     before do
       Honeycomb.start_span(name: "test") do


### PR DESCRIPTION
There are cases where a beeline user would like to get access to the
libhoney instance directly. This makes it possible by calling
`Honeycomb.libhoney` at any time.