### PR TITLE
Serializes ActionController::Parameters correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     honeycomb-beeline (1.3.0)
-      libhoney (~> 1.8)
+      libhoney (~> 1.14, >= 1.14.2)
 
 GEM
   remote: https://rubygems.org/
@@ -31,20 +31,20 @@ GEM
       ffi (>= 1.0.0)
       rake
     hashdiff (0.4.0)
-    http (4.2.0)
+    http (4.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
-      http-form_data (~> 2.0)
+      http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (2.1.1)
+    http-form_data (2.3.0)
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     iniparse (1.4.4)
     jaro_winkler (1.5.3)
     json (2.2.0)
-    libhoney (1.14.1)
+    libhoney (1.14.4)
       addressable (~> 2.0)
       http (>= 2.0, < 5.0)
     method_source (0.9.2)
@@ -127,4 +127,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "libhoney", "~> 1.8"
+  spec.add_dependency "libhoney", ">= 1.14.2", "~> 1.14"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bump"

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/notifications"
+require "libhoney/cleaner"
 
 module Honeycomb
   module ActiveSupport
@@ -8,6 +9,8 @@ module Honeycomb
     # Included in the configuration object to specify events that should be
     # subscribed to
     module Configuration
+      include Libhoney::Cleaner
+
       attr_accessor :notification_events
 
       def after_initialize(client)
@@ -34,7 +37,8 @@ module Honeycomb
           on_notification_event.call(name, span, payload)
         else
           payload.each do |key, value|
-            span.add_field("#{name}.#{key}", value.to_s)
+            value = value.to_hash if value.respond_to?(:to_hash)
+            span.add_field("#{name}.#{key}", clean_data(value))
           end
         end
       end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -34,7 +34,7 @@ module Honeycomb
           on_notification_event.call(name, span, payload)
         else
           payload.each do |key, value|
-            # Transforms ActionController::Parameters into something libhoney parses.
+            # Make ActionController::Parameters parseable by libhoney.
             value = value.to_unsafe_hash if value.respond_to?(:to_unsafe_hash)
             span.add_field("#{name}.#{key}", value)
           end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/notifications"
-require "libhoney/cleaner"
 
 module Honeycomb
   module ActiveSupport
@@ -9,8 +8,6 @@ module Honeycomb
     # Included in the configuration object to specify events that should be
     # subscribed to
     module Configuration
-      include Libhoney::Cleaner
-
       attr_accessor :notification_events
 
       def after_initialize(client)
@@ -37,8 +34,9 @@ module Honeycomb
           on_notification_event.call(name, span, payload)
         else
           payload.each do |key, value|
-            value = value.to_hash if value.respond_to?(:to_hash)
-            span.add_field("#{name}.#{key}", clean_data(value))
+            # Transforms ActionController::Parameters into something libhoney parses.
+            value = value.to_unsafe_hash if value.respond_to?(:to_unsafe_hash)
+            span.add_field("#{name}.#{key}", value)
           end
         end
       end

--- a/spec/honeycomb/integrations/active_support_spec.rb
+++ b/spec/honeycomb/integrations/active_support_spec.rb
@@ -75,16 +75,17 @@ if defined?(Honeycomb::ActiveSupport)
       end
       let!(:client) { Honeycomb::Client.new(configuration: configuration) }
       let(:event_data) { libhoney_client.events.map(&:data) }
-      let(:event_name) { "honeycomb.test_event" }
+      let(:event_name) { "hny.test_event" }
 
-      let(:params) { ActionController::Parameters.new(a: "123", b: "456") }
+      let(:params) { ActionController::Parameters.new(a: "1", b: "2") }
       before do
-        ActiveSupport::Notifications.instrument event_name, "honeycomb" => params do
+        ActiveSupport::Notifications.instrument(event_name,
+                                                "params" => params) do
         end
       end
 
       let(:event) { event_data.last }
-      let(:fields) { {"honeycomb.test_event.honeycomb" => {"a" => "123", "b" => "456"}} }
+      let(:fields) { { "hny.test_event.params" => { "a" => "1", "b" => "2" } } }
 
       it "sends the expected fields on success" do
         expect(event).to include(fields)


### PR DESCRIPTION
Don't prematurely call to_s on hashes, as we can actually serialize them in a way we can parse.

This enables us to construct nested JSON in libhoney, serializing things so they can be later unpacked on Honeycomb's side.