### PR TITLE
Update rake version (CVE-2020-8130)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.1.1)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (13.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -118,7 +118,7 @@ DEPENDENCIES
   honeycomb-beeline!
   overcommit (~> 0.46.0)
   pry-byebug
-  rake
+  rake (>= 12.3.3)
   rspec (~> 3.0)
   rubocop (< 0.69)
   rubocop-performance (< 1.3.0)
@@ -127,4 +127,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "overcommit", "~> 0.46.0"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "< 0.69"
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"


### PR DESCRIPTION
Updating to address security vulnerability flagged by Github (CVE-2020-8130)