### PR TITLE
Include endpoint argument to all clients

### DIFF
--- a/spec/honeycomb/integrations/aws_spec.rb
+++ b/spec/honeycomb/integrations/aws_spec.rb
@@ -52,7 +52,7 @@ if defined?(Honeycomb::Aws)
       end
 
       it "is enabled by default" do
-        aws = aws_clients.sample.new
+        aws = aws_clients.sample.new(endpoint: "https://honeycomb.io")
         expect(aws.handlers).to include(
           Honeycomb::Aws::SdkHandler,
           Honeycomb::Aws::ApiHandler,
@@ -60,7 +60,8 @@ if defined?(Honeycomb::Aws)
       end
 
       it "can be disabled" do
-        aws = aws_clients.sample.new(honeycomb: false)
+        aws = aws_clients.sample.new(endpoint: "https://honeycomb.io",
+                                     honeycomb: false)
         expect(aws.handlers).not_to include(
           Honeycomb::Aws::SdkHandler,
           Honeycomb::Aws::ApiHandler,
@@ -68,12 +69,13 @@ if defined?(Honeycomb::Aws)
       end
 
       it "uses the global Honeycomb client by default" do
-        aws = aws_clients.sample.new
+        aws = aws_clients.sample.new(endpoint: "https://honeycomb.io")
         expect(aws.config.honeycomb_client).to be Honeycomb.client
       end
 
       it "can be configured with a different Honeycomb client" do
-        aws = aws_clients.sample.new(honeycomb_client: client)
+        aws = aws_clients.sample.new(endpoint: "https://honeycomb.io",
+                                     honeycomb_client: client)
         expect(aws.config.honeycomb_client).to be client
       end
     end


### PR DESCRIPTION
We have intermittent test failures with the AWS tests. This should hopefully fix them although ideally we should not be relying on sample to obtain a client as this is not very deterministic.

In order to reproduce this I ran the following under both the aws-2 and was-3 appraisal profiles

`bundle exec appraisal aws-2 bundle console`
```
Aws.config.update(stub_responses: true)
clients = Aws::Partitions.service_ids.keys.map {|service| Aws.const_get(service).const_get(:Client)}
clients.map do |c|
  begin
    c.new
  rescue => e
    @err = e
  ensure
    puts "#{@err} #{c}" if @err
    @err = nil
  end
end
```

`bundle exec appraisal aws-3 bundle console`
```
Aws.config.update(stub_responses: true)
clients = Aws::Partitions.service_ids.keys.map {|service| Aws.const_get(service).const_get(:Client)}
clients.map do |c|
  begin
    c.new
  rescue => e
    @err = e
  ensure
    puts "#{@err} #{c}" if @err
    @err = nil
  end
end
```

When running the code with `aws-2`, we get the following output, which looks suspiciously like the intermittent test failures that we see.

```
no member 'regional_endpoint' in struct Aws::CloudSearchDomain::Client
missing required option `:endpoint' Aws::IoTDataPlane::Client
```

I then altered the code to the following to see if we could provide the endpoint argument to all of the clients with no ill effect.

```
clients.map do |c|
  begin
    c.new(endpoint: "https://honeycomb.io")
  rescue => e
    @err = e
  ensure
    puts "#{@err} #{c}" if @err
    @err = nil
  end
end
```

This ran successfully on both `aws-2` and `aws-3` with no clients unable to be constructed.

cc: @ajvondrak 