### PR TITLE
Properly pass options for Ruby 2.7

### DIFF
--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -33,7 +33,7 @@ module Honeycomb
 
       @client ||
         (debug && Libhoney::LogClient.new) ||
-        Libhoney::Client.new(options)
+        Libhoney::Client.new(**options)
     end
 
     def after_initialize(client)


### PR DESCRIPTION
In Ruby 2.7 passing the last argument as an options hash if the receiver uses keyword arguments is no longer allowed and emits a deprecation warning.

This PR applies the recommended fix of adding ** to covert the options hash into the correct keyword arg format.

There may be more deprecation warnings to fix in other parts of the codebase but these were the ones that jumped out to me right away.