### PR TITLE
Trigger a nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,16 +62,17 @@ jobs:
           command: bundle exec rake test
 
 workflows:
-  beeline:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
-      - lint:
-          filters:
-              tags:
-                only: /.*/
-      - test:
-          filters:
-              tags:
-                only: /.*/
+      - lint
+      - test: &test
           requires:
             - lint
           matrix:
@@ -109,6 +110,17 @@ workflows:
                 gemfile: gemfiles/rails_41.gemfile
               - ruby-version: "2.7"
                 gemfile: gemfiles/rails_42.gemfile
+  beeline:
+    jobs:
+      - lint:
+          filters:
+              tags:
+                only: /.*/
+      - test:
+          <<: *test
+          filters:
+              tags:
+                only: /.*/
       - publish:
           filters:
               tags:


### PR DESCRIPTION
Adds a workflow that runs once a day to lint and test whatever is on master. Followed these docs, no idea if it works or not https://circleci.com/docs/2.0/triggers/

It would be nice to stay on top of build failures like this https://github.com/honeycombio/beeline-ruby/pull/86 rather than have people submit PRs that fail to build because of some dependency failing.

