### PR TITLE
[WIP] Provide hooks and utils for trace header interop

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -10,7 +10,9 @@ module Honeycomb
   class Client
     extend Forwardable
 
-    attr_reader :libhoney
+    attr_reader :libhoney,
+                :trace_http_header_propagation_hook,
+                :trace_http_header_parser_hook
 
     def_delegators :@context, :current_span, :current_trace
 
@@ -31,6 +33,11 @@ module Honeycomb
       # maybe make `service_name` a required parameter
       @libhoney.add_field "service_name", configuration.service_name
       @context = Context.new
+
+      @trace_http_header_propagation_hook =
+        configuration.trace_http_header_propagation_hook
+      @trace_http_header_parser_hook =
+        configuration.trace_http_header_parser_hook
 
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -60,5 +60,21 @@ module Honeycomb
         @sample_hook
       end
     end
+
+    def trace_http_header_propagation_hook(&hook)
+      if block_given?
+        @trace_http_header_propagation_hook = hook
+      else
+        @trace_http_header_propagation_hook
+      end
+    end
+
+    def trace_http_header_parser_hook(&hook)
+      if block_given?
+        @trace_http_header_parser_hook = hook
+      else
+        @trace_http_header_parser_hook
+      end
+    end
   end
 end


### PR DESCRIPTION
In order to support interoperability between services instrumented with Honeycomb beelines and services instrumented with other tracing formats (OpenTelemetry, OpenCensus, Jaeger), we are providing configurable hooks that allow a caller to specify parsers and propagators for specific header wire formats.