### PR TITLE
Fix Redis 4.2 test failures

### DIFF
--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -147,7 +147,7 @@ if defined?(Honeycomb::Redis)
 
       it "sends the expected fields on success" do
         command
-        expect(event).to match(fields)
+        expect(event).to include(fields)
       end
 
       it "sends the expected fields on failure" do
@@ -155,7 +155,7 @@ if defined?(Honeycomb::Redis)
         expect(connection).to receive(:write).and_raise(exn.new("detail"))
         expect { command }.to raise_error(exn)
         error = { "redis.error" => exn.name, "redis.error_detail" => "detail" }
-        expect(event).to match(fields.merge(error))
+        expect(event).to include(fields.merge(error))
       end
     end
 
@@ -170,7 +170,7 @@ if defined?(Honeycomb::Redis)
               redis.client.command_map[:blah] = "auth"
             end
             redis.blah("password")
-            expect(event).to match(fields)
+            expect(event).to include(fields)
           end
         end
       end


### PR DESCRIPTION
Redis 4.2 added some additional properties that the redis integration sucks in. 

Using `match` requires that the hash exactly match what is given.

We can just use the fields as the minimum and use `include` so that this doesn't break in the future.
