### PR TITLE
Fix missing response code bug

### DIFF
--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -45,16 +45,19 @@ module Honeycomb
         span.add_field("request.secure", req.ssl?)
         span.add_field("request.xhr", req.xhr?)
 
-        status, headers, body = app.call(env)
+        begin
+          status, headers, body = app.call(env)
 
-        add_package_information(env, &add_field)
+          add_package_information(env, &add_field)
 
-        extract_user_information(env, &add_field)
+          extract_user_information(env, &add_field)
 
-        span.add_field("response.status_code", status)
-        span.add_field("response.content_type", headers["Content-Type"])
+          span.add_field("response.content_type", headers["Content-Type"])
 
-        [status, headers, body]
+          [status, headers, body]
+        ensure
+          span.add_field("response.status_code", status || 500)
+        end
       end
     end
 


### PR DESCRIPTION
I found honeycomb didn't trace some 500 responses because it's set `response.status_code` after `status, headers, body = app.call(env)`, so if the call raise error, honeycomb client can't set `response.status_code`.

Usually, by this situation, the server would return 500 response, it's very important for honeycomb to be aware of this since by my understanding honeycomb should capture tracings according to response code.