### PR TITLE
remove children after sending

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Metrics/LineLength:
   Exclude:
     - spec/support/event_data_shared_examples.rb
 
+Metrics/ParameterLists:
+  Max: 6
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Exclude:

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -92,14 +92,7 @@ module Honeycomb
     end
 
     def send_internal
-      add_field "duration_ms", duration_ms
-      add_field "trace.trace_id", trace.id
-      add_field "trace.span_id", id
-      add_field "meta.span_type", span_type
-      parent_id && add_field("trace.parent_id", parent_id)
-      add rollup_fields
-      add trace.fields
-      span_type == "root" && add(trace.rollup_fields)
+      add_additional_fields
       send_children
       sample = true
       if sample_hook.nil?
@@ -114,6 +107,17 @@ module Honeycomb
       end
       @sent = true
       context.span_sent(self)
+    end
+
+    def add_additional_fields
+      add_field "duration_ms", duration_ms
+      add_field "trace.trace_id", trace.id
+      add_field "trace.span_id", id
+      add_field "meta.span_type", span_type
+      parent_id && add_field("trace.parent_id", parent_id)
+      add rollup_fields
+      add trace.fields
+      span_type == "root" && add(trace.rollup_fields)
     end
 
     def send_children

--- a/spec/honeycomb/span_spec.rb
+++ b/spec/honeycomb/span_spec.rb
@@ -110,4 +110,21 @@ RSpec.describe Honeycomb::Span do
       end
     end
   end
+
+  describe "sending children and parents" do
+    let(:parent) do
+      Honeycomb::Span.new(trace: trace,
+                          builder: builder,
+                          context: context)
+    end
+
+    subject(:child) { parent.create_child }
+
+    it "will remove itself from it's parent after being sent" do
+      expect(child).not_to receive(:send_by_parent)
+
+      child.send
+      parent.send
+    end
+  end
 end

--- a/spec/honeycomb/span_spec.rb
+++ b/spec/honeycomb/span_spec.rb
@@ -24,86 +24,90 @@ end
 
 RSpec.describe Honeycomb::Span do
   let(:libhoney_client) { Libhoney::TestClient.new }
-  let(:presend_hook) { nil }
-  let(:sample_rate) { 1 }
-  let(:sample_hook) do
-    lambda do |_fields|
-      [sampling_decision, sample_rate]
-    end
-  end
   let(:context) { Honeycomb::Context.new }
   let(:builder) { libhoney_client.builder }
   let(:trace) { Honeycomb::Trace.new(builder: builder, context: context) }
-  subject(:span) do
-    Honeycomb::Span.new(trace: trace,
-                        builder: builder,
-                        context: context,
-                        sample_hook: sample_hook,
-                        presend_hook: presend_hook)
-  end
 
-  describe "when the sampling hook returns false" do
-    let(:sampling_decision) { false }
-
-    it "does not send the event" do
-      expect { span.send }.not_to(change { libhoney_client.events })
-    end
-  end
-
-  describe "when a span creates a child span" do
-    let(:presend_hook) { double("PresendHook") }
-    let(:sample_hook) { double("SampleHook") }
-
-    before do
-      allow(presend_hook).to receive(:call)
-      # we have to configure the sample_hook here to return the expected value
-      # as the presend_hook will not be called if the event is not going to be
-      # sent
-      allow(sample_hook).to receive(:call).and_return([true, 0])
+  describe "sample_hook and presend_hook behaviour" do
+    let(:presend_hook) { nil }
+    let(:sample_rate) { 1 }
+    let(:sample_hook) do
+      lambda do |_fields|
+        [sampling_decision, sample_rate]
+      end
     end
 
-    it "sets the sample_hook on the child" do
-      expect(sample_hook).to receive(:call)
-        .with(hash_including("honeycomb" => "bees"))
-
-      child = span.create_child
-      child.add_field("honeycomb", "bees")
-      child.send
+    subject(:span) do
+      Honeycomb::Span.new(trace: trace,
+                          builder: builder,
+                          context: context,
+                          sample_hook: sample_hook,
+                          presend_hook: presend_hook)
     end
 
-    it "sets the presend_hook on the child" do
-      expect(presend_hook).to receive(:call)
-        .with(hash_including("honeycomb" => "bees"))
+    describe "when the sampling hook returns false" do
+      let(:sampling_decision) { false }
 
-      child = span.create_child
-      child.add_field("honeycomb", "bees")
-      child.send
-    end
-  end
-
-  describe "when the sampling hook returns true" do
-    let(:presend_hook) { double("PresendHook") }
-    let(:sampling_decision) { true }
-    let(:sample_rate) { 10 }
-
-    it "sends the event" do
-      allow(presend_hook).to receive(:call)
-      expect { span.send }.to change { libhoney_client.events.count }.by(1)
+      it "does not send the event" do
+        expect { span.send }.not_to(change { libhoney_client.events })
+      end
     end
 
-    it "calls the presend hook" do
-      expect(presend_hook).to receive(:call)
-        .with(hash_including("honeycomb" => "bees"))
+    describe "when a span creates a child span" do
+      let(:presend_hook) { double("PresendHook") }
+      let(:sample_hook) { double("SampleHook") }
 
-      span.add_field("honeycomb", "bees")
-      span.send
+      before do
+        allow(presend_hook).to receive(:call)
+        # we have to configure the sample_hook here to return the expected value
+        # as the presend_hook will not be called if the event is not going to be
+        # sent
+        allow(sample_hook).to receive(:call).and_return([true, 0])
+      end
+
+      it "sets the sample_hook on the child" do
+        expect(sample_hook).to receive(:call)
+          .with(hash_including("honeycomb" => "bees"))
+
+        child = span.create_child
+        child.add_field("honeycomb", "bees")
+        child.send
+      end
+
+      it "sets the presend_hook on the child" do
+        expect(presend_hook).to receive(:call)
+          .with(hash_including("honeycomb" => "bees"))
+
+        child = span.create_child
+        child.add_field("honeycomb", "bees")
+        child.send
+      end
     end
 
-    it "sets the correct sample rate on the event" do
-      allow(presend_hook).to receive(:call)
-      span.send
-      expect(libhoney_client.events)
-        .to all(have_attributes(sample_rate: sample_rate))
+    describe "when the sampling hook returns true" do
+      let(:presend_hook) { double("PresendHook") }
+      let(:sampling_decision) { true }
+      let(:sample_rate) { 10 }
+
+      it "sends the event" do
+        allow(presend_hook).to receive(:call)
+        expect { span.send }.to change { libhoney_client.events.count }.by(1)
+      end
+
+      it "calls the presend hook" do
+        expect(presend_hook).to receive(:call)
+          .with(hash_including("honeycomb" => "bees"))
+
+        span.add_field("honeycomb", "bees")
+        span.send
+      end
+
+      it "sets the correct sample rate on the event" do
+        allow(presend_hook).to receive(:call)
+        span.send
+        expect(libhoney_client.events)
+          .to all(have_attributes(sample_rate: sample_rate))
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #84.

The spec changes look really bad, but the main change is to dump the existing specs into another `describe` block and add an additional spec to check that after the child is sent it won't try to send any sent children. Might be easiest to just look at the last two commits as the shuffling around is isolated to the first commit.

