### PR TITLE
Add ruby 2.2 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ workflows:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
+              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
               gemfile:
                 - gemfiles/aws_2.gemfile
                 - gemfiles/aws_3.gemfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,12 @@ workflows:
                 - gemfiles/redis_3.gemfile
                 - gemfiles/redis_4.gemfile
             exclude:
+              - ruby-version: "2.2"
+                gemfile: gemfiles/faraday_1.gemfile
+              - ruby-version: "2.2"
+                gemfile: gemfiles/rails_52.gemfile
+              - ruby-version: "2.2"
+                gemfile: gemfiles/rails_6.gemfile
               - ruby-version: "2.3"
                 gemfile: gemfiles/rails_6.gemfile
               - ruby-version: "2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.0)
     bump (0.9.0)
-    byebug (11.1.3)
+    byebug (10.0.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -56,8 +56,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.7.0)
-      byebug (~> 11.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (4.0.4)
     rainbow (3.0.0)
@@ -116,7 +116,7 @@ DEPENDENCIES
   honeycomb-beeline!
   overcommit (~> 0.46.0)
   pry (< 0.13.0)
-  pry-byebug (~> 3.7.0)
+  pry-byebug (~> 3.6.0)
   rake
   rspec (~> 3.0)
   rubocop (< 0.69)

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "overcommit", "~> 0.46.0"
   spec.add_development_dependency "pry", "< 0.13.0"
-  spec.add_development_dependency "pry-byebug", "~> 3.7.0"
+  spec.add_development_dependency "pry-byebug", "~> 3.6.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "< 0.69"


### PR DESCRIPTION
We claim to support ruby 2.2 in the `gemspec` yet we don't run any of our tests on this version of ruby.

Adds 2.2 to the matrix and excludes framework versions that don't run on 2.2
