### PR TITLE
fix(client): reference current span in start_span

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -62,18 +62,16 @@ module Honeycomb
 
       current_span.add_field("name", name)
 
-      if block_given?
-        begin
-          yield current_span
-        rescue StandardError => e
-          current_span.add_field("error", e.class.name)
-          current_span.add_field("error_detail", e.message)
-          raise e
-        ensure
-          current_span.send
-        end
-      else
-        current_span
+      return current_span unless block_given?
+
+      begin
+        yield current_span
+      rescue StandardError => e
+        current_span.add_field("error", e.class.name)
+        current_span.add_field("error_detail", e.message)
+        raise e
+      ensure
+        current_span.send
       end
     end
 

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -54,24 +54,26 @@ module Honeycomb
         context.current_span.create_child
       end
 
+      current_span = context.current_span
+
       fields.each do |key, value|
-        context.current_span.add_field(key, value)
+        current_span.add_field(key, value)
       end
 
-      context.current_span.add_field("name", name)
+      current_span.add_field("name", name)
 
       if block_given?
         begin
-          yield context.current_span
+          yield current_span
         rescue StandardError => e
-          context.current_span.add_field("error", e.class.name)
-          context.current_span.add_field("error_detail", e.message)
+          current_span.add_field("error", e.class.name)
+          current_span.add_field("error_detail", e.message)
           raise e
         ensure
-          context.current_span.send
+          current_span.send
         end
       else
-        context.current_span
+        current_span
       end
     end
 

--- a/spec/honeycomb/client_spec.rb
+++ b/spec/honeycomb/client_spec.rb
@@ -158,14 +158,24 @@ RSpec.describe Honeycomb::Client do
 
   describe "sending from within a span block" do
     it "does not also send the parent span" do
-      root_span = client.start_span(name: "root")
-      client.start_span(name: "child", &:send)
-      expect(root_span.__send__(:sent?)).to be false
+      client.start_span(name: "root")
+
+      # rubocop:disable Style/SymbolProc
+      client.start_span(name: "child") do |child_span|
+        child_span.send
+      end
+      # rubocop:enable Style/SymbolProc
+
+      expect(libhoney_client.events.size).to eq 1
     end
 
     it "does not raise an error when the span is the root" do
       expect do
-        client.start_span(name: "child", &:send)
+        # rubocop:disable Style/SymbolProc
+        client.start_span(name: "child") do |child_span|
+          child_span.send
+        end
+        # rubocop:enable Style/SymbolProc
       end.to_not raise_error
     end
   end

--- a/spec/honeycomb/client_spec.rb
+++ b/spec/honeycomb/client_spec.rb
@@ -155,4 +155,18 @@ RSpec.describe Honeycomb::Client do
 
     it_behaves_like "event data", package_fields: false
   end
+
+  describe "sending from within a span block" do
+    it "does not also send the parent span" do
+      root_span = client.start_span(name: "root")
+      client.start_span(name: "child", &:send)
+      expect(root_span.__send__(:sent?)).to be false
+    end
+
+    it "does not raise an error when the span is the root" do
+      expect do
+        client.start_span(name: "child", &:send)
+      end.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Updates the Client#start_span method to store a reference to the current span, rather than repeatedly referencing `context.current_span`.

The method `Span#send` is a public method, which means that it is possible for instrumentation to send the span from within a block passed to `Client#start_span`. Under those circumstances, one of two problematic scenarios can occur:

1) If the current span is _not_ the root span, then start_span will end up sending the parent span instead of the child span.
2) If the current span _is_ the root span, then start_span will raise `ArgumentError: no method name given`. This is due to the fact that `context.current_span` returns `nil` and `NilClass#send` expects a parameter, i.e. the method name to send.

By storing a reference to the current span, we can guarantee that `Client#start_span` will always be operating on the correct span. Given that `Span#send` is idempotent, calling `#send` after a block has already sent the span is safe.