### PR TITLE
fix: increase margin for sampling distribution test

### DIFF
--- a/spec/honeycomb/deterministic_sampler_spec.rb
+++ b/spec/honeycomb/deterministic_sampler_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Honeycomb::DeterministicSampler do
 
   include_examples "sampling distribution", 1, 0.05
   include_examples "sampling distribution", 2, 0.05
-  include_examples "sampling distribution", 10, 0.05
+  include_examples "sampling distribution", 10, 0.06
 end
 
 RSpec.describe Honeycomb::DeterministicSampler do


### PR DESCRIPTION
This should do the trick for the bounds that is occasionally not met in tests.
For sample_rate of 10, we've been using a margin of 0.05, which tests for `samples` to be within 250.00 of the 5000 `expected`. It's occasionally a few outside of that, leading to very occasional build failure.
Bumping to 0.06 will increase the bounds enough that we're still checking sufficiently without running into this break. (5000 * 0.06 == 300)
