### PR TITLE
[draft-wip] add custom parse and propagation hook configs

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -10,7 +10,7 @@ module Honeycomb
   class Client
     extend Forwardable
 
-    attr_reader :libhoney, :propagation_hooks
+    attr_reader :libhoney, :parser_hook
 
     def_delegators :@context, :current_span, :current_trace
 
@@ -32,15 +32,14 @@ module Honeycomb
       @libhoney.add_field "service_name", configuration.service_name
       @context = Context.new
 
-      @propagation_hooks = {
-        custom_parser_hook: configuration.http_trace_parser_hook,
-      }
-
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,
         sample_hook: configuration.sample_hook,
-        custom_propagation_hook: configuration.http_trace_propagation_hook,
+        propagation_hook: configuration.http_trace_propagation_hook,
+        parser_hook: configuration.http_trace_parser_hook,
       }
+
+      @parser_hook = @additional_trace_options[:parser_hook]
 
       configuration.after_initialize(self)
 

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -34,12 +34,13 @@ module Honeycomb
 
       @propagation_hooks = {
         custom_parser_hook: configuration.http_trace_parser_hook,
-        custom_propagation_hook: configuration.http_trace_propagation_hook,
+        #custom_propagation_hook: configuration.http_trace_propagation_hook,
       }
 
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,
         sample_hook: configuration.sample_hook,
+        custom_propagation_hook: configuration.http_trace_propagation_hook,
       }
 
       configuration.after_initialize(self)

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -34,7 +34,6 @@ module Honeycomb
 
       @propagation_hooks = {
         custom_parser_hook: configuration.http_trace_parser_hook,
-        #custom_propagation_hook: configuration.http_trace_propagation_hook,
       }
 
       @additional_trace_options = {

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -70,7 +70,6 @@ module Honeycomb
     end
 
     def http_trace_propagation_hook(&hook)
-      puts "configuration"
       if block_given?
         @http_trace_propagation_hook = hook
       else

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -70,6 +70,7 @@ module Honeycomb
     end
 
     def http_trace_propagation_hook(&hook)
+      puts "configuration"
       if block_given?
         @http_trace_propagation_hook = hook
       else

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -60,5 +60,21 @@ module Honeycomb
         @sample_hook
       end
     end
+
+    def http_trace_parser_hook(&hook)
+      if block_given?
+        @http_trace_parser_hook = hook
+      else
+        @http_trace_parser_hook
+      end
+    end
+
+    def http_trace_propagation_hook(&hook)
+      if block_given?
+        @http_trace_propagation_hook = hook
+      else
+        @http_trace_propagation_hook
+      end
+    end
   end
 end

--- a/lib/honeycomb/integrations/faraday.rb
+++ b/lib/honeycomb/integrations/faraday.rb
@@ -24,6 +24,7 @@ module Honeycomb
 
         env.request_headers["X-Honeycomb-Trace"] = span.to_trace_header
 
+
         @app.call(env).tap do |response|
           span.add_field "response.status_code", response.status
         end

--- a/lib/honeycomb/integrations/faraday.rb
+++ b/lib/honeycomb/integrations/faraday.rb
@@ -15,18 +15,7 @@ module Honeycomb
 
       @client.start_span(name: "http_client") do |span|
         request_headers = env.request_headers
-        puts request_headers
-        puts "faraday start_span"
-        #puts span.create_headers(hook: span.custom_propagation_hook)
-        puts span.custom_propagation_hook
-        puts "after puts custom hook"
-
-        serialized_headers = span.create_headers(hook: span.custom_propagation_hook)
-        #serialized_headers = span.create_headers
-        puts "after assigning serialized_headers"
-
-        puts serialized_headers
-        puts "after serialized_headers"
+        serialized_headers = span.create_headers
 
         span.add_field "request.method", env.method.upcase
         span.add_field "request.scheme", env.url.scheme
@@ -35,15 +24,11 @@ module Honeycomb
         span.add_field "meta.type", "http_client"
         span.add_field "meta.package", "faraday"
         span.add_field "meta.package_version", ::Faraday::VERSION
-        puts "about to merge objects"
 
-        #env.request_headers = request_headers.merge(serialized_headers)
-        #puts env.request_headers
-        puts response
-        #@app.call(env).tap do |response|
-         # span.add_field "response.status_code", response.status
-        #end
-        puts "end of block"
+        env.request_headers = request_headers.merge(serialized_headers)
+        @app.call(env).tap do |response|
+          span.add_field "response.status_code", response.status
+        end
       end
     end
   end

--- a/lib/honeycomb/integrations/faraday.rb
+++ b/lib/honeycomb/integrations/faraday.rb
@@ -14,6 +14,20 @@ module Honeycomb
       return @app.call(env) if @client.nil?
 
       @client.start_span(name: "http_client") do |span|
+        request_headers = env.request_headers
+        puts request_headers
+        puts "faraday start_span"
+        #puts span.create_headers(hook: span.custom_propagation_hook)
+        puts span.custom_propagation_hook
+        puts "after puts custom hook"
+
+        serialized_headers = span.create_headers(hook: span.custom_propagation_hook)
+        #serialized_headers = span.create_headers
+        puts "after assigning serialized_headers"
+
+        puts serialized_headers
+        puts "after serialized_headers"
+
         span.add_field "request.method", env.method.upcase
         span.add_field "request.scheme", env.url.scheme
         span.add_field "request.host", env.url.host
@@ -21,13 +35,15 @@ module Honeycomb
         span.add_field "meta.type", "http_client"
         span.add_field "meta.package", "faraday"
         span.add_field "meta.package_version", ::Faraday::VERSION
+        puts "about to merge objects"
 
-        env.request_headers["X-Honeycomb-Trace"] = span.to_trace_header
-
-
-        @app.call(env).tap do |response|
-          span.add_field "response.status_code", response.status
-        end
+        #env.request_headers = request_headers.merge(serialized_headers)
+        #puts env.request_headers
+        puts response
+        #@app.call(env).tap do |response|
+         # span.add_field "response.status_code", response.status
+        #end
+        puts "end of block"
       end
     end
   end

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -37,7 +37,7 @@ module Honeycomb
 
       custom_parser_hook = client.propagation_hooks[:custom_parser_hook]
       propagation_context = parse(env, parser_hook: custom_parser_hook)
-
+      puts "not broken"
       client.start_span(
         name: "http_request",
         serialized_trace: hny,

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -34,8 +34,7 @@ module Honeycomb
     def call(env)
       req = ::Rack::Request.new(env)
       hny = env["HTTP_X_HONEYCOMB_TRACE"]
-
-      custom_parser_hook = client.propagation_hooks[:custom_parser_hook]
+      custom_parser_hook = client.parser_hook
       propagation_context = parse_request(env, parser_hook: custom_parser_hook)
 
       client.start_span(

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -6,8 +6,6 @@ require "honeycomb/integrations/warden"
 module Honeycomb
   # Rack specific methods for building middleware
   module Rack
-    #include HoneycombPropagation::UnmarshalTraceContext
-
     RACK_FIELDS = [
       ["REQUEST_METHOD", "request.method"],
       ["PATH_INFO", "request.path"],

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -6,6 +6,8 @@ require "honeycomb/integrations/warden"
 module Honeycomb
   # Rack specific methods for building middleware
   module Rack
+    #include HoneycombPropagation::UnmarshalTraceContext
+
     RACK_FIELDS = [
       ["REQUEST_METHOD", "request.method"],
       ["PATH_INFO", "request.path"],
@@ -34,8 +36,10 @@ module Honeycomb
       req = ::Rack::Request.new(env)
       hny = env["HTTP_X_HONEYCOMB_TRACE"]
 
-      propagation_context = client.parse_header(env)
-
+      custom_parser_hook = client.propagation_hooks[:custom_parser_hook]
+      propagation_context = PropagationParser.parse(
+        env, parser_hook: custom_parser_hook
+      )
       client.start_span(
         name: "http_request",
         serialized_trace: hny,

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -6,6 +6,7 @@ require "honeycomb/integrations/warden"
 module Honeycomb
   # Rack specific methods for building middleware
   module Rack
+    include PropagationParser
     RACK_FIELDS = [
       ["REQUEST_METHOD", "request.method"],
       ["PATH_INFO", "request.path"],
@@ -35,9 +36,8 @@ module Honeycomb
       hny = env["HTTP_X_HONEYCOMB_TRACE"]
 
       custom_parser_hook = client.propagation_hooks[:custom_parser_hook]
-      propagation_context = PropagationParser.parse(
-        env, parser_hook: custom_parser_hook
-      )
+      propagation_context = parse(env, parser_hook: custom_parser_hook)
+
       client.start_span(
         name: "http_request",
         serialized_trace: hny,

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -36,8 +36,8 @@ module Honeycomb
       hny = env["HTTP_X_HONEYCOMB_TRACE"]
 
       custom_parser_hook = client.propagation_hooks[:custom_parser_hook]
-      propagation_context = parse(env, parser_hook: custom_parser_hook)
-      puts "not broken"
+      propagation_context = parse_request(env, parser_hook: custom_parser_hook)
+
       client.start_span(
         name: "http_request",
         serialized_trace: hny,

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -33,7 +33,14 @@ module Honeycomb
     def call(env)
       req = ::Rack::Request.new(env)
       hny = env["HTTP_X_HONEYCOMB_TRACE"]
-      client.start_span(name: "http_request", serialized_trace: hny) do |span|
+
+      propagation_context = client.parse_header(env)
+
+      client.start_span(
+        name: "http_request",
+        serialized_trace: hny,
+        propagation_context: propagation_context,
+      ) do |span|
         add_field = lambda do |key, value|
           unless value.nil? || (value.respond_to?(:empty?) && value.empty?)
             span.add_field(key, value)

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -27,21 +27,14 @@ module Honeycomb
   # Serialize trace headers
   module PropagationSerializer
     include HoneycombPropagation::MarshalTraceContext
-
-    def create_headers(hook:)
-      puts hook
-      begin
-        if hook.nil?
-          puts "nil hook"
-          create_hash
-        else
-          puts "has custom hook"
-          hook.call
-        end
-      rescue => error
-        puts "error"
-        puts error
+    def create_headers
+      if custom_propagation_hook.nil?
+        create_hash
+      else
+        custom_propagation_hook.call(propagation_context)
       end
+    rescue StandardError => e
+      raise e
     end
   end
 end

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -5,18 +5,19 @@ require "json"
 require "uri"
 
 require "honeycomb/propagation/honeycomb"
+require "honeycomb/propagation/w3c"
+require "honeycomb/propagation/aws"
 
 module Honeycomb
   # Parse trace headers
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
 
-    def self.get_propagation_context(env:, hook:)
-      if hook.nil?
-        hny = env["HTTP_X_HONEYCOMB_TRACE"]
-        parse(hny)
+    def self.parse(env, parser_hook:)
+      if parser_hook.nil?
+        http_trace_parser_hook(env)
       else
-        hook.call(env)
+        parser_hook.call(env)
       end
     end
   end

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -12,8 +12,10 @@ module Honeycomb
   # Parse trace headers
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
-
-    def parse(env, parser_hook: nil)
+    
+    # parse_request both pulls the trace headers out
+    # and parses them, returning a propagation context
+    def parse_request(env, parser_hook: nil)
       if parser_hook.nil?
         http_trace_parser_hook(env)
       else

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -13,7 +13,7 @@ module Honeycomb
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
 
-    def self.parse(env, parser_hook:)
+    def parse(env, parser_hook:)
       if parser_hook.nil?
         http_trace_parser_hook(env)
       else

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -13,7 +13,7 @@ module Honeycomb
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
 
-    def parse(env, parser_hook:)
+    def parse(env, parser_hook: nil)
       if parser_hook.nil?
         http_trace_parser_hook(env)
       else

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -10,6 +10,15 @@ module Honeycomb
   # Parse trace headers
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
+
+    def self.get_propagation_context(env:, hook:)
+      if hook.nil?
+        hny = env["HTTP_X_HONEYCOMB_TRACE"]
+        parse(hny)
+      else
+        hook.call(env)
+      end
+    end
   end
 
   # Serialize trace headers

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -28,10 +28,10 @@ module Honeycomb
   module PropagationSerializer
     include HoneycombPropagation::MarshalTraceContext
     def create_headers
-      if custom_propagation_hook.nil?
+      if propagation_hook.nil?
         create_hash
       else
-        custom_propagation_hook.call(propagation_context)
+        propagation_hook.call(propagation_context_from_span)
       end
     rescue StandardError => e
       raise e

--- a/lib/honeycomb/propagation.rb
+++ b/lib/honeycomb/propagation.rb
@@ -12,7 +12,7 @@ module Honeycomb
   # Parse trace headers
   module PropagationParser
     include HoneycombPropagation::UnmarshalTraceContext
-    
+
     # parse_request both pulls the trace headers out
     # and parses them, returning a propagation context
     def parse_request(env, parser_hook: nil)
@@ -27,5 +27,21 @@ module Honeycomb
   # Serialize trace headers
   module PropagationSerializer
     include HoneycombPropagation::MarshalTraceContext
+
+    def create_headers(hook:)
+      puts hook
+      begin
+        if hook.nil?
+          puts "nil hook"
+          create_hash
+        else
+          puts "has custom hook"
+          hook.call
+        end
+      rescue => error
+        puts "error"
+        puts error
+      end
+    end
   end
 end

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -11,8 +11,7 @@ module Honeycomb
     module UnmarshalTraceContext
       def http_trace_parser_hook(env)
         hny = env["HTTP_X_HONEYCOMB_TRACE"]
-        parse(hny) unless hny.nil?
-        [nil, nil, nil, nil]
+        parse(hny)
       end
 
       def parse(serialized_trace)

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -70,6 +70,10 @@ module Honeycomb
         ]
         "1;#{data_to_propogate.join(',')}"
       end
+
+      def create_hash
+        { "X-Honeycomb-Trace" => to_trace_header }
+      end
     end
   end
 end

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -9,9 +9,9 @@ module Honeycomb
   module HoneycombPropagation
     # Parse trace headers
     module UnmarshalTraceContext
-      def http_trace_parser_hook(env:)
+      def http_trace_parser_hook(env)
         hny = env["HTTP_X_HONEYCOMB_TRACE"]
-        parse(hny)
+        parse(hny) unless hny.nil?
       end
 
       def parse(serialized_trace)

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -12,9 +12,11 @@ module Honeycomb
       def http_trace_parser_hook(env)
         hny = env["HTTP_X_HONEYCOMB_TRACE"]
         parse(hny) unless hny.nil?
+        [nil, nil, nil, nil]
       end
 
       def parse(serialized_trace)
+        puts serialized_trace
         unless serialized_trace.nil?
           version, payload = serialized_trace.split(";", 2)
 

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -9,6 +9,11 @@ module Honeycomb
   module HoneycombPropagation
     # Parse trace headers
     module UnmarshalTraceContext
+      def http_trace_parser_hook(env:)
+        hny = env["HTTP_X_HONEYCOMB_TRACE"]
+        parse(hny)
+      end
+
       def parse(serialized_trace)
         unless serialized_trace.nil?
           version, payload = serialized_trace.split(";", 2)

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -15,7 +15,6 @@ module Honeycomb
       end
 
       def parse(serialized_trace)
-        puts serialized_trace
         unless serialized_trace.nil?
           version, payload = serialized_trace.split(";", 2)
 

--- a/lib/honeycomb/propagation/w3c.rb
+++ b/lib/honeycomb/propagation/w3c.rb
@@ -52,7 +52,6 @@ module Honeycomb
 
       def to_trace_header(context: nil)
         trace_id, span_id = get_ids(context)
-        puts trace_id
         unless trace_id.nil? || span_id.nil?
           return "00-#{trace_id}-#{span_id}-01"
         end
@@ -68,7 +67,7 @@ module Honeycomb
 
       def get_ids(context)
         trace_id = context.nil? ? trace.id : context["trace_id"]
-        span_id = context.nil? ? id : context["span_id"]
+        span_id = context.nil? ? id : context["parent_span_id"]
 
         # do not propagate malformed ids
         if trace_id =~ TRACE_ID_REGEX && span_id =~ SPAN_ID_REGEX

--- a/lib/honeycomb/propagation/w3c.rb
+++ b/lib/honeycomb/propagation/w3c.rb
@@ -51,7 +51,7 @@ module Honeycomb
       SPAN_ID_REGEX = /^[A-Fa-f0-9]{16}$/.freeze
 
       def to_trace_header(context: nil)
-        trace_id, span_id = get_ids(context)
+        trace_id, span_id = context
         unless trace_id.nil? || span_id.nil?
           return "00-#{trace_id}-#{span_id}-01"
         end
@@ -61,20 +61,6 @@ module Honeycomb
 
       def create_hash(context: nil)
         { "traceparent" => to_trace_header(context: context) }
-      end
-
-      private
-
-      def get_ids(context)
-        trace_id = context.nil? ? trace.id : context["trace_id"]
-        span_id = context.nil? ? id : context["parent_span_id"]
-
-        # do not propagate malformed ids
-        if trace_id =~ TRACE_ID_REGEX && span_id =~ SPAN_ID_REGEX
-          return [trace_id, span_id]
-        end
-
-        [nil, nil]
       end
     end
   end

--- a/lib/honeycomb/propagation/w3c.rb
+++ b/lib/honeycomb/propagation/w3c.rb
@@ -50,6 +50,10 @@ module Honeycomb
 
         nil
       end
+
+      def create_hash
+        { "traceparent" => to_trace_header }
+      end
     end
   end
 end

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -41,6 +41,7 @@ module Honeycomb
                       is_root: parent_id.nil?,
                       sample_hook: nil,
                       presend_hook: nil,
+                      http_trace_propagation_hook: nil,
                       **_options)
       @parent = parent
       # parent_id should be removed in the next major version bump. It has been
@@ -50,6 +51,7 @@ module Honeycomb
       @is_root = is_root
       @presend_hook = presend_hook
       @sample_hook = sample_hook
+      @http_trace_propagation_hook = http_trace_propagation_hook
     end
 
     def create_child
@@ -59,6 +61,7 @@ module Honeycomb
                      parent: self,
                      parent_id: id,
                      sample_hook: sample_hook,
+                     http_trace_propagation_hook: http_trace_propagation_hook,
                      presend_hook: presend_hook).tap do |c|
         children << c
       end
@@ -94,7 +97,8 @@ module Honeycomb
                 :builder,
                 :context,
                 :presend_hook,
-                :sample_hook
+                :sample_hook,
+                :http_trace_propagation_hook
 
     def sent?
       @sent

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -18,12 +18,13 @@ module Honeycomb
     def_delegators :@event, :add_field, :add
     def_delegator :@trace, :add_field, :add_trace_field
 
-    attr_reader :id, :trace
+    attr_reader :id, :trace, :custom_propagation_hook
 
     def initialize(trace:,
                    builder:,
                    context:,
                    **options)
+      puts options[:additional_trace_options]
       @id = generate_span_id
       @context = context
       @context.current_span = self
@@ -41,7 +42,7 @@ module Honeycomb
                       is_root: parent_id.nil?,
                       sample_hook: nil,
                       presend_hook: nil,
-                      http_trace_propagation_hook: nil,
+                      custom_propagation_hook: nil,
                       **_options)
       @parent = parent
       # parent_id should be removed in the next major version bump. It has been
@@ -51,7 +52,7 @@ module Honeycomb
       @is_root = is_root
       @presend_hook = presend_hook
       @sample_hook = sample_hook
-      @http_trace_propagation_hook = http_trace_propagation_hook
+      @custom_propagation_hook = custom_propagation_hook
     end
 
     def create_child
@@ -61,7 +62,7 @@ module Honeycomb
                      parent: self,
                      parent_id: id,
                      sample_hook: sample_hook,
-                     http_trace_propagation_hook: http_trace_propagation_hook,
+                     custom_propagation_hook: custom_propagation_hook,
                      presend_hook: presend_hook).tap do |c|
         children << c
       end
@@ -97,8 +98,7 @@ module Honeycomb
                 :builder,
                 :context,
                 :presend_hook,
-                :sample_hook,
-                :http_trace_propagation_hook
+                :sample_hook
 
     def sent?
       @sent

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -24,7 +24,6 @@ module Honeycomb
                    builder:,
                    context:,
                    **options)
-      puts options[:additional_trace_options]
       @id = generate_span_id
       @context = context
       @context.current_span = self
@@ -73,6 +72,16 @@ module Honeycomb
 
       send_internal
     end
+
+    def propagation_context
+      {
+        "span_id" => id,
+        "trace_id" => trace.id,
+        "trace_context" => trace.fields,
+        "dataset" => builder.dataset,
+      }
+    end
+
 
     protected
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -36,7 +36,7 @@ module Honeycomb
       parse_options(**options)
     end
 
-    def parse_options(parent: nil,
+    def parse_options(parent: nil, # rubocop:disable Metrics/ParameterLists
                       parent_id: nil,
                       is_root: parent_id.nil?,
                       sample_hook: nil,
@@ -81,7 +81,6 @@ module Honeycomb
         "dataset" => builder.dataset,
       }
     end
-
 
     protected
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -73,11 +73,12 @@ module Honeycomb
       send_internal
     end
 
+    # for passing a propagation context object for a current Span
     def propagation_context
       {
-        "span_id" => id,
+        "parent_span_id" => id,
         "trace_id" => trace.id,
-        "trace_context" => trace.fields,
+        "trace_fields" => trace.fields,
         "dataset" => builder.dataset,
       }
     end

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -18,7 +18,7 @@ module Honeycomb
     def_delegators :@event, :add_field, :add
     def_delegator :@trace, :add_field, :add_trace_field
 
-    attr_reader :id, :trace, :custom_propagation_hook
+    attr_reader :id, :trace, :propagation_hook
 
     def initialize(trace:,
                    builder:,
@@ -41,7 +41,7 @@ module Honeycomb
                       is_root: parent_id.nil?,
                       sample_hook: nil,
                       presend_hook: nil,
-                      custom_propagation_hook: nil,
+                      propagation_hook: nil,
                       **_options)
       @parent = parent
       # parent_id should be removed in the next major version bump. It has been
@@ -51,7 +51,7 @@ module Honeycomb
       @is_root = is_root
       @presend_hook = presend_hook
       @sample_hook = sample_hook
-      @custom_propagation_hook = custom_propagation_hook
+      @propagation_hook = propagation_hook
     end
 
     def create_child
@@ -61,7 +61,7 @@ module Honeycomb
                      parent: self,
                      parent_id: id,
                      sample_hook: sample_hook,
-                     custom_propagation_hook: custom_propagation_hook,
+                     propagation_hook: propagation_hook,
                      presend_hook: presend_hook).tap do |c|
         children << c
       end
@@ -74,13 +74,13 @@ module Honeycomb
     end
 
     # for passing a propagation context object for a current Span
-    def propagation_context
-      {
-        "parent_span_id" => id,
-        "trace_id" => trace.id,
-        "trace_fields" => trace.fields,
-        "dataset" => builder.dataset,
-      }
+    def propagation_context_from_span
+      trace_id = trace.id
+      parent_span_id = id
+      trace_fields = trace.fields
+      dataset = builder.dataset
+
+      [trace_id, parent_span_id, trace_fields, dataset]
     end
 
     protected

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -17,9 +17,23 @@ module Honeycomb
 
     attr_reader :id, :fields, :root_span
 
-    def initialize(builder:, context:, serialized_trace: nil, **options)
-      trace_id, parent_span_id, trace_fields, dataset =
-        parse serialized_trace
+    def initialize(
+      builder:, context:,
+      serialized_trace: nil,
+      propagation_context: nil,
+      **options
+    )
+
+      # if a propagation context hash was successfully created, use that
+      # otherwise fall back to previous behavior of parsing a string
+      if propagation_context
+        trace_id, parent_span_id, trace_fields, dataset =
+          propagation_context
+      else
+        trace_id, parent_span_id, trace_fields, dataset =
+          parse serialized_trace
+      end
+
       dataset && builder.dataset = dataset
       @id = trace_id || generate_trace_id
       @fields = trace_fields || {}
@@ -29,6 +43,10 @@ module Honeycomb
                             builder: builder,
                             context: context,
                             **options)
+    end
+
+    def parse_header(hook)
+      puts hook
     end
 
     def add_field(key, value)

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -34,6 +34,7 @@ module Honeycomb
           parse serialized_trace
       end
 
+      puts options
       dataset && builder.dataset = dataset
       @id = trace_id || generate_trace_id
       @fields = trace_fields || {}

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -45,10 +45,6 @@ module Honeycomb
                             **options)
     end
 
-    def parse_header(hook)
-      puts hook
-    end
-
     def add_field(key, value)
       @fields[key] = value
     end

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -23,7 +23,6 @@ module Honeycomb
       propagation_context: nil,
       **options
     )
-
       # if a propagation context hash was successfully created, use that
       # otherwise fall back to previous behavior of parsing a string
       if propagation_context

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -33,8 +33,6 @@ module Honeycomb
         trace_id, parent_span_id, trace_fields, dataset =
           parse serialized_trace
       end
-
-      puts options
       dataset && builder.dataset = dataset
       @id = trace_id || generate_trace_id
       @fields = trace_fields || {}

--- a/spec/honeycomb/propagation/w3c_spec.rb
+++ b/spec/honeycomb/propagation/w3c_spec.rb
@@ -71,12 +71,7 @@ RSpec.describe Honeycomb::W3CPropagation::MarshalTraceContext do
       .extend(subject)
   end
   let(:propagation_context) do
-    return {
-      "parent_span_id" => parent_id,
-      "trace_id" => trace_id,
-      "trace_fields" => {},
-      "dataset" => builder.dataset,
-    }
+    return [trace_id, parent_id, {}, builder.dataset]
   end
 
   let(:w3c_propagation) do
@@ -84,7 +79,7 @@ RSpec.describe Honeycomb::W3CPropagation::MarshalTraceContext do
   end
 
   it "can serialize a basic span" do
-    expect(span.to_trace_header)
+    expect(span.to_trace_header(context: propagation_context))
       .to eq("00-#{trace_id}-#{parent_id}-01")
   end
 
@@ -131,13 +126,16 @@ RSpec.describe "Propagation" do
     instance_double("Span", id: parent_id, trace: trace, builder: builder)
       .extend(Honeycomb::W3CPropagation::MarshalTraceContext)
   end
+  let(:propagation_context) do
+    return [trace_id, parent_id, {}, builder.dataset]
+  end
 
   let(:w3c_parsing) do
     Class.new.extend(Honeycomb::W3CPropagation::UnmarshalTraceContext)
   end
 
   let(:header) do
-    w3c_parsing.parse(span.to_trace_header)
+    w3c_parsing.parse(span.to_trace_header(context: propagation_context))
   end
 
   it "returns nil dataset" do


### PR DESCRIPTION
Enable custom hook configurations for trace header parsing and propagation.
- similar to the other beelines, the `propagation_context` hash will be used as the intermediary data structure for both parsing and propagation. i.e. propagation hooks expect access to a propagation context for the current span at the time of the outbound request, and parsing hooks are required to return a `propagation_context`