### PR TITLE
Add configuration for excluding child spans when a parent span is sam…

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -35,10 +35,10 @@ module Honeycomb
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,
         sample_hook: configuration.sample_hook,
+        sample_excludes_child_spans: configuration.sample_excludes_child_spans,
         parser_hook: configuration.http_trace_parser_hook,
         propagation_hook: configuration.http_trace_propagation_hook,
       }
-
       configuration.after_initialize(self)
 
       at_exit do

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -9,6 +9,7 @@ module Honeycomb
     attr_accessor :write_key,
                   :dataset,
                   :api_host,
+                  :sample_excludes_child_spans,
                   :debug
 
     attr_writer :service_name, :client, :host_name

--- a/lib/honeycomb/context.rb
+++ b/lib/honeycomb/context.rb
@@ -17,7 +17,7 @@ module Honeycomb
       spans << span
     end
 
-    def span_sent(span)
+    def span_finished(span)
       spans.last != span && raise(ArgumentError, "Incorrect span sent")
 
       spans.pop

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -68,7 +68,11 @@ module Honeycomb
 
         handler_for(name).call(name, span, payload)
 
-        span.send
+        if span.parent
+          span.will_send_by_parent!
+        else
+          span.send
+        end
       end
 
       private

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -30,6 +30,7 @@ module Honeycomb
       end
 
       def handle_notification_event(name, span, payload)
+
         if on_notification_event
           on_notification_event.call(name, span, payload)
         else

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -68,11 +68,7 @@ module Honeycomb
 
         handler_for(name).call(name, span, payload)
 
-        if span.parent
-          span.will_send_by_parent!
-        else
-          span.send
-        end
+        span.send
       end
 
       private

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -83,6 +83,7 @@ module Honeycomb
       return if sent?
       if parent && @sample_excludes_child_spans
         will_send_by_parent!
+        return
       end
 
       send_internal

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -73,7 +73,7 @@ module Honeycomb
                      sample_hook: sample_hook,
                      presend_hook: presend_hook,
                      propagation_hook: propagation_hook,
-                     sample_excludes_child_spans: nil
+                     sample_excludes_child_spans: @sample_excludes_child_spans
                      ).tap do |c|
         children << c
       end

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -95,6 +95,7 @@ module Honeycomb
 
     def will_send_by_parent!
       @will_send_by_parent = true
+      add_additional_fields
       context.span_finished(self)
     end
 
@@ -169,9 +170,9 @@ module Honeycomb
     end
 
     def send_internal
-      add_additional_fields
+      add_additional_fields unless @will_send_by_parent
       sample = sampling_says_send?
-      # puts " * " + (" " * span_ancestors.length) + "- " + event.data['name'] + "(#{sample})"
+      # puts " * " + (" " * span_ancestors.length) + "- " + event.data['name'] + "(#{sample}, #{@event.data['duration_ms']})"
 
       send_children
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -81,6 +81,9 @@ module Honeycomb
 
     def send
       return if sent?
+      if parent && @sample_excludes_child_spans
+        will_send_by_parent!
+      end
 
       send_internal
     end
@@ -123,6 +126,7 @@ module Honeycomb
       end
 
       if @sampling_says_send == nil
+        add_additional_fields # Safe to call multiple times.
         if sample_hook.nil?
           @sampling_says_send = should_sample(event.sample_rate, trace.id)
         else


### PR DESCRIPTION
While not able to support interprocess traces, sampling all child spans makes it easy to decide a toplevel trace is 'not interesting' and discard all data associated with it.