### PR TITLE
Use nil for config dataset when empty

### DIFF
--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -6,9 +6,10 @@ module Honeycomb
   # Used to configure the Honeycomb client
   class Configuration
     attr_accessor :write_key,
-                  :dataset,
                   :api_host,
                   :debug
+
+    attr_reader :dataset
 
     attr_writer :service_name, :client, :host_name
 
@@ -18,6 +19,10 @@ module Honeycomb
       @service_name = ENV["HONEYCOMB_SERVICE"]
       @debug = ENV.key?("HONEYCOMB_DEBUG")
       @client = nil
+    end
+
+    def dataset=(dataset)
+      @dataset = dataset.empty? ? nil : dataset
     end
 
     def service_name

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -67,4 +67,14 @@ RSpec.describe Honeycomb::Configuration do
       expect(configuration.service_name).to eq service_name
     end
   end
+
+  describe "empty dataset" do
+    before do
+      configuration.dataset = ""
+    end
+
+    it "sets dataset to nil" do
+      expect(configuration.dataset).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
An empty dataset can cause issues and should default to `nil`.