### PR TITLE
Add rspec filter :focus for assisting with debugging tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,4 +34,7 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # allow :focus to be applied to specific tests for debugging
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
Allows for marking spec functions with `:focus` to assist with debugging.