### PR TITLE
Revert "Move Middleware to be before ActionDispatch::ShowExceptions"

### DIFF
--- a/lib/honeycomb/integrations/railtie.rb
+++ b/lib/honeycomb/integrations/railtie.rb
@@ -6,17 +6,15 @@ require "honeycomb/integrations/rails"
 module Honeycomb
   # Automatically capture rack requests and create a trace
   class Railtie < ::Rails::Railtie
-    def self.insert_middleware(app, client)
-      app.config.middleware.insert_before(
-        ActionDispatch::ShowExceptions,
-        Honeycomb::Rails::Middleware,
-        client: client,
-      )
-    end
-
     initializer("honeycomb.install_middleware",
                 after: :load_config_initializers) do |app|
-      self.class.insert_middleware(app, Honeycomb.client) if Honeycomb.client
+      if Honeycomb.client
+        app.config.middleware.insert_after(
+          ActionDispatch::ShowExceptions,
+          Honeycomb::Rails::Middleware,
+          client: Honeycomb.client,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Reverts honeycombio/beeline-ruby#123

After discussing with team, we feel this change in its current form necessitates a major version bump due to `error` and `error_details` going missing on 4xx and 5xx requests. Going to pull it out of `main` so we can continue the release train, and open a new PR for this change so we can attempt to make it backwards-compatible or merge into a 3.x.x branch.