### PR TITLE
Ensure status_code is set on the event, when there is an exception

### DIFF
--- a/lib/honeycomb/integrations/railtie.rb
+++ b/lib/honeycomb/integrations/railtie.rb
@@ -6,15 +6,17 @@ require "honeycomb/integrations/rails"
 module Honeycomb
   # Automatically capture rack requests and create a trace
   class Railtie < ::Rails::Railtie
+    def self.insert_middleware(app, client)
+      app.config.middleware.insert_before(
+        ActionDispatch::ShowExceptions,
+        Honeycomb::Rails::Middleware,
+        client: client,
+      )
+    end
+
     initializer("honeycomb.install_middleware",
                 after: :load_config_initializers) do |app|
-      if Honeycomb.client
-        app.config.middleware.insert_after(
-          ActionDispatch::ShowExceptions,
-          Honeycomb::Rails::Middleware,
-          client: Honeycomb.client,
-        )
-      end
+      self.class.insert_middleware(app, Honeycomb.client) if Honeycomb.client
     end
   end
 end


### PR DESCRIPTION
This brings back the change from #123 

* this will ensure status_code is always set on the event, even when it's a 4xx and 5xx response
* without additional work this will remove error and error_detail from event in those cases, making this a breaking change