### PR TITLE
Improve performance of Redis command serialization

### DIFF
--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -2186,6 +2186,21 @@ if defined?(Honeycomb::Redis)
         expect(command).to eq 'ECHO "hi\\\\ho"'
       end
 
+      it "escapes backslashes followed by x" do
+        redis.echo("hi\\xho")
+        expect(command).to eq 'ECHO "hi\\\\xho"'
+      end
+
+      it "escapes backslashes followed by x and a single hex digit" do
+        redis.echo("hi\\x1ho")
+        expect(command).to eq 'ECHO "hi\\\\x1ho"'
+      end
+
+      it "will not escape backslashes that look like hex escape sequences" do
+        redis.echo("hi\\x1Aho")
+        expect(command).to eq 'ECHO "hi\\x1Aho"'
+      end
+
       it "escapes double quotes" do
         redis.echo('hi"ho')
         expect(command).to eq 'ECHO "hi\\"ho"'


### PR DESCRIPTION
Fixes #57.

There was a major performance bottleneck in the Redis integration when prettifying the `redis.command` field. The original implementation would scan the string character-by-character and manually push possibly-escaped results to another string. This implementation replaces that manual logic with some strategic uses of `String#encode!` and `String#gsub!`.

There's a minor regression in the behavior with the interaction between invalid UTF-8 bytes and basic backslash escaping, but I think the payoff is well worth it. I added tests to codify this new behavior.

Using this benchmark:

```ruby
require "bundler/inline"

gemfile do
  gem "honeycomb-beeline", path: "~/repos/beeline-ruby"
  gem "redis", source: "https://rubygems.org"
end

require "benchmark"
require "net/http"

html = Net::HTTP.get(URI("https://www.honeycomb.io/"))

Benchmark.benchmark do |bm|
  bm.report("Honeycomb::Redis::Fields#command=") do
    client = OpenStruct.new(id: "bench", command_map: {})
    fields = Honeycomb::Redis::Fields.new(client)
    100.times do
      fields.command = [[:set, "fragment", html]]
    end
  end
end
```

I see more than an order of magnitude performance improvement on my machine.

**Before**

```
Honeycomb::Redis::Fields#command=  4.471124   0.013693   4.484817 (  4.494411)
```

**After**

```
Honeycomb::Redis::Fields#command=  0.320487   0.008812   0.329299 (  0.330399)
```
