### PR TITLE
Updates Redis event-field filter to handle string keys in options in addition to symbol keys.

### DIFF
--- a/lib/honeycomb/integrations/redis.rb
+++ b/lib/honeycomb/integrations/redis.rb
@@ -159,7 +159,17 @@ module Honeycomb
       # * :logger - just some Ruby object, not useful
       # * :_parsed - implementation detail
       def ignore?(option)
-        %i[url password logger _parsed].include?(option)
+        # Redis options may be symbol or string keys.
+        #
+        # This normalizes `option` using `to_sym` as benchmarking on Ruby MRI
+        # v2.6.6 and v2.7.3 has shown that was faster compared to `to_s`.
+        # However, `nil` does not support `to_sym`. This uses a guard clause to
+        # handle the `nil` case because this is still faster than safe
+        # navigation. Also this lib still supports Ruby 2.2.0; which does not
+        # include safe navigation.
+        return true unless option
+
+        %i[url password logger _parsed].include?(option.to_sym)
       end
 
       def format(cmd)


### PR DESCRIPTION
The honeycomb-beeline Redis integration attempts to [sanitize fields][1] to remove sensitive data. Unfortunately, it expects the fields to be symbol keys. For people who create their own Redis connections, it is probably likely that this is an issue; as the Redis docs use symbol names. However, the Redis lib is flexible enough to support string keys. Additionally, the Rails' Action Cable Redis configuration uses a "hash with indifferent access" which internally utilizes string keys.

This adds option key normalization to support both symbol and string keys for field filtering. The choice to convert to `to_sym` instead of `to_s` was based on some basic benchmarking of the two. Further, benchmarking comparing a guard clause with safe navigation was also performed (NOTE: this lib still supports Ruby 2.2.0 which does not have safe navigation so that isn't really an option anyways).

The results of both benchmarks show that using `to_sym` and a guard clause is the generally more performant option.

## Benchmarks

### Environment

MacBook Pro
3.1 GHz Quad-Core Intel Core i7
16 GB 2133 MHz LPDDR3

ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin19]
ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-darwin19]

benchmark-ips v2.8.3
kalibera v0.1.1

### Benchmark: `to_s` vs `to_sym`

<details>
<summary>Code: to_s_vs_to_sym.rb</summary>

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem "benchmark-ips", "~> 2.8"
  gem "kalibera", "~> 0.1"
end

require 'kalibera'
require 'benchmark/ips'

def value_to_s(val)
  return unless val

  val.to_s
end

def value_to_sym(val)
  return unless val

  val.to_sym
end

GC.start
Benchmark.ips do |bench|
  bench.config stats: :bootstrap, confidence: 95

  bench.report("Symbol.to_s") do
    value_to_s(:anything)
  end

  bench.report("Symbol.to_sym") do
    value_to_sym(:anything)
  end

  bench.report("String.to_s") do
    value_to_s("anything")
  end

  bench.report("String.to_sym") do
    value_to_sym("anything")
  end

  bench.compare!
end
```

</details>

#### Results: Ruby 2.6.6

```
Warming up --------------------------------------
         Symbol.to_s   837.428k i/100ms
       Symbol.to_sym     1.341M i/100ms
         String.to_s     1.328M i/100ms
       String.to_sym   868.763k i/100ms
Calculating -------------------------------------
         Symbol.to_s      8.305M (± 0.8%) i/s -     41.871M in   5.045895s
       Symbol.to_sym     13.014M (± 0.9%) i/s -     65.725M in   5.056039s
         String.to_s     12.919M (± 0.7%) i/s -     65.083M in   5.041092s
       String.to_sym      8.710M (± 0.6%) i/s -     44.307M in   5.089477s
                   with 95.0% confidence

Comparison:
       Symbol.to_sym: 13013692.7 i/s
         String.to_s: 12919052.1 i/s - same-ish: difference falls within error
       String.to_sym:  8709628.3 i/s - 1.49x  (± 0.02) slower
         Symbol.to_s:  8305245.2 i/s - 1.57x  (± 0.02) slower
                   with 95.0% confidence
```

#### Results: Ruby 2.7.3

```
Warming up --------------------------------------
         Symbol.to_s   738.693k i/100ms
       Symbol.to_sym     1.202M i/100ms
         String.to_s     1.168M i/100ms
       String.to_sym   794.984k i/100ms
Calculating -------------------------------------
         Symbol.to_s      7.506M (± 0.7%) i/s -     37.673M in   5.021353s
       Symbol.to_sym     12.356M (± 0.6%) i/s -     62.488M in   5.060048s
         String.to_s     11.916M (± 0.9%) i/s -     59.585M in   5.006738s
       String.to_sym      7.907M (± 0.9%) i/s -     39.749M in   5.032495s
                   with 95.0% confidence

Comparison:
       Symbol.to_sym: 12356400.1 i/s
         String.to_s: 11915781.4 i/s - 1.04x  (± 0.01) slower
       String.to_sym:  7907486.2 i/s - 1.56x  (± 0.02) slower
         Symbol.to_s:  7505968.0 i/s - 1.65x  (± 0.02) slower
                   with 95.0% confidence
```

### Benchmark: Guard vs Safe Navigation

<details>
<summary>Code: include_guard_vs_safe_navigation.rb</summary>

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem "benchmark-ips", "~> 2.8"
  gem "kalibera", "~> 0.1"
end

require 'kalibera'
require 'benchmark/ips'

def contains_guard(val)
  return true unless val

  %i[url password logger _parsed].include?(val.to_sym)
end

def contains_safe_navigation(val)
  %i[url password logger _parsed].include?(val&.to_sym)
end

GC.start
Benchmark.ips do |bench|
  bench.config stats: :bootstrap, confidence: 95

  bench.report("guard(nil)") do
    contains_guard(nil)
  end

  bench.report("safe_nav(nil)") do
    contains_safe_navigation(nil)
  end

  bench.report("guard exclude") do
    contains_guard(:excludes)
  end

  bench.report("safe_nav exclude") do
    contains_safe_navigation(:excludes)
  end

  bench.report("guard include") do
    contains_guard(:password)
  end

  bench.report("safe_nav include") do
    contains_safe_navigation(:password)
  end

  bench.compare!
end
```

</details>

#### Results: Ruby 2.6.6

```
Warming up --------------------------------------
          guard(nil)     1.910M i/100ms
       safe_nav(nil)   550.959k i/100ms
       guard exclude   618.420k i/100ms
    safe_nav exclude   660.640k i/100ms
       guard include   771.624k i/100ms
    safe_nav include   765.230k i/100ms
Calculating -------------------------------------
          guard(nil)     19.090M (± 0.5%) i/s -     95.519M in   5.005690s
       safe_nav(nil)      5.635M (± 0.4%) i/s -     28.650M in   5.084940s
       guard exclude      6.834M (± 0.6%) i/s -     34.632M in   5.070376s
    safe_nav exclude      6.603M (± 1.6%) i/s -     33.032M in   5.031208s
       guard include      7.666M (± 0.8%) i/s -     38.581M in   5.037820s
    safe_nav include      7.780M (± 0.6%) i/s -     39.027M in   5.018548s
                   with 95.0% confidence

Comparison:
          guard(nil): 19089705.6 i/s
    safe_nav include:  7779618.2 i/s - 2.45x  (± 0.02) slower
       guard include:  7665931.7 i/s - 2.49x  (± 0.02) slower
       guard exclude:  6833623.0 i/s - 2.79x  (± 0.02) slower
    safe_nav exclude:  6603012.5 i/s - 2.89x  (± 0.05) slower
       safe_nav(nil):  5635454.0 i/s - 3.39x  (± 0.02) slower
                   with 95.0% confidence
```

#### Results: Ruby 2.7.3

```
Warming up --------------------------------------
          guard(nil)     1.680M i/100ms
       safe_nav(nil)   458.364k i/100ms
       guard exclude   600.724k i/100ms
    safe_nav exclude   598.514k i/100ms
       guard include   638.002k i/100ms
    safe_nav include   695.605k i/100ms
Calculating -------------------------------------
          guard(nil)     16.536M (± 1.0%) i/s -     83.992M in   5.089328s
       safe_nav(nil)      4.501M (± 0.6%) i/s -     22.918M in   5.094096s
       guard exclude      5.888M (± 0.5%) i/s -     30.036M in   5.102613s
    safe_nav exclude      5.981M (± 0.6%) i/s -     29.926M in   5.005423s
       guard include      6.489M (± 0.8%) i/s -     32.538M in   5.018895s
    safe_nav include      6.696M (± 1.9%) i/s -     34.085M in   5.121491s
                   with 95.0% confidence

Comparison:
          guard(nil): 16535956.5 i/s
    safe_nav include:  6695921.2 i/s - 2.47x  (± 0.05) slower
       guard include:  6489483.8 i/s - 2.55x  (± 0.03) slower
    safe_nav exclude:  5981362.2 i/s - 2.76x  (± 0.03) slower
       guard exclude:  5888279.2 i/s - 2.81x  (± 0.03) slower
       safe_nav(nil):  4500780.4 i/s - 3.67x  (± 0.04) slower
                   with 95.0% confidence
```

Deep Dive Into Rails 5.2.6 Action Cable Redis Configuration
-----------------------------------------------------------

The Rails configuration is on [ActionCable::Server::Base.config][2] and that is passed into the [`:action_cable` on load hook][3]. The Rails Action Cable engine uses that hook to define the [configuration using a hash-with-indifferent-access][4]. Later that hash-with-indifferent-access has options [sliced out of it and passed into `Redis.new`][5]. When you call `slice` on a hash-with-indifferent-access you get a hash-with-indifferent-access back. These hash like objects utilize `String` keys under the hood. They also provide `String` keys to enumerable methods like `each`.

Since the Reds instance `@options` hash has `String` keys the Honeycomb sanitization process does not match the keys and the sensitive values slip through into the fields.

[1]: https://github.com/honeycombio/beeline-ruby/blob/v2.4.0/lib/honeycomb/integrations/redis.rb#L155-L163
[2]: https://github.com/rails/rails/blob/v5.2.6/actioncable/lib/action_cable/server/base.rb#L15
[3]: https://github.com/rails/rails/blob/v5.2.6/actioncable/lib/action_cable/server/base.rb#L87
[4]: https://github.com/rails/rails/blob/v5.2.6/actioncable/lib/action_cable/engine.rb#L32-L34
[5]: https://github.com/rails/rails/blob/v5.2.6/actioncable/lib/action_cable/subscription_adapter/redis.rb#L15-L17