### PR TITLE
Switch from Thread to RequestStore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     honeycomb-beeline (2.4.1)
       libhoney (~> 1.14, >= 1.14.2)
+      request_store
 
 GEM
   remote: https://rubygems.org/
@@ -66,8 +67,11 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (4.0.4)
+    rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "libhoney", ">= 1.14.2", "~> 1.14"
+  spec.add_dependency "request_store"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bump"

--- a/lib/honeycomb/context.rb
+++ b/lib/honeycomb/context.rb
@@ -30,7 +30,7 @@ module Honeycomb
     end
 
     def storage
-      Thread.current[thread_key] ||= {}
+      RequestStore.store[thread_key] ||= {}
     end
 
     def thread_key

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -75,7 +75,7 @@ module Honeycomb
       attr_reader :key, :client, :handlers
 
       def spans
-        Thread.current[key] ||= Hash.new { |h, id| h[id] = [] }
+        RequestStore.store[key] ||= Hash.new { |h, id| h[id] = [] }
       end
 
       def handler_for(name)


### PR DESCRIPTION
### Summary
Goodday my fellow tracing enthusiastic!

I noticed that the beeline is making use of `Thread.current` as its' context storage solution for the life of the request. During my time in the Ruby on Rails weeds, I've been exposed to some oddities and unreliabilities whilst using `Thread.current`. So, I have returned to offer a discussion in the form of a pull request. Unfortunately, I do not have any examples as I last debugged the beeline several months ago.

For more context on "The Problem" I'd like to link the **README.md** for the `RequestStore`:
https://github.com/steveklabnik/request_store#the-problem

With some added context here:
https://github.com/rails/rails/issues/8517#issuecomment-11438876