### PR TITLE
Add ability to configure custom fields during Honeycomb configuration

### DIFF
--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -30,6 +30,11 @@ module Honeycomb
 
       # maybe make `service_name` a required parameter
       @libhoney.add_field "service_name", configuration.service_name
+
+      configuration.custom_fields.each do |key, value|
+        @libhoney.add_field key, value
+      end
+
       @context = Context.new
 
       @additional_trace_options = {

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -19,6 +19,7 @@ module Honeycomb
       @service_name = ENV["HONEYCOMB_SERVICE"]
       @debug = ENV.key?("HONEYCOMB_DEBUG")
       @client = nil
+      @custom_fields = {}
     end
 
     def service_name


### PR DESCRIPTION
### Summary
The ability to add custom fields during the configuration of a Honeycomb client can be extremely useful. Added flexibility can allow users to produce richer telemetry and enhance query capabilities. While this can be done during span creation, there are cases where a user may want to set additional fields during client creation which would, in turn, attach itself to **all** events.

An example, _for us_, is that we have a `sandbox` dataset where we'd like to further slice our data based on the "team" (given we have multiple sandboxes for teams to use). While this could also be achieved by configuring multiple datasets, there are architectural decisions that make it useful to have these data points present in the same dataset.

### Example Usage
```ruby
Honeycomb.configure do |config|
  config.dataset = "sandbox"
  config.service_name = "some-application-name"
  config.custom_fields = { team_name: "flow" }
  # ...
end
```

### If accepted, what's left?
- [ ] Specs
- [ ] Documentation Snippet