### PR TITLE
make Rails spec consistent with Honeycomb Railtie initialization

### DIFF
--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -37,8 +37,6 @@ if defined?(Honeycomb::Rails)
     let(:client) { Honeycomb::Client.new(configuration: configuration) }
     let(:app) do
       Class.new(Rails::Application).tap do |app|
-        app.config.logger = Logger.new(STDERR)
-        app.config.log_level = :fatal
         app.config.eager_load = false
         app.config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c4"
         app.config.respond_to?(:hosts) && app.config.hosts << "example.org"

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -112,11 +112,6 @@ if defined?(Honeycomb::Rails)
         get "/hello_error?honey=bee"
       end
 
-      # TODO: remove these lets when we add shared_examples
-      # because they're declared in
-      let(:event_data) { libhoney_client.events.map(&:data) }
-      let(:event) { event_data.first }
-
       it "returns internal server" do
         expect(last_response).to be_server_error
       end

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -155,7 +155,8 @@ if defined?(Honeycomb::Rails)
       end
 
       it "returns error details with the span" do
-        expect(event["error_detail"]).to eq "Invalid query parameters: Invalid encoding for parameter: �"
+        expect(event["error_detail"])
+          .to eq "Invalid query parameters: Invalid encoding for parameter: �"
       end
 
       include_examples "the rails integration" do
@@ -179,7 +180,8 @@ if defined?(Honeycomb::Rails)
       end
 
       it "returns error details with the span" do
-        expect(event["error_detail"]).to eq 'No route matches [GET] "/unrecognized"'
+        expect(event["error_detail"])
+          .to eq 'No route matches [GET] "/unrecognized"'
       end
 
       include_examples "the rails integration" do

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -151,6 +151,18 @@ if defined?(Honeycomb::Rails)
         end
       end
 
+      it "returns an invalid request status code" do
+        expect(event["response.status_code"]).to eq 400
+      end
+
+      it "returns error with the span" do
+        expect(event["error"]).to eq "ActionController::BadRequest"
+      end
+
+      it "returns error details with the span" do
+        expect(event["error_detail"]).to eq "Invalid query parameters: Invalid encoding for parameter: �"
+      end
+
       include_examples "the rails integration" do
         let(:controller) { "test" }
         let(:action) { "hello" }
@@ -165,6 +177,14 @@ if defined?(Honeycomb::Rails)
 
       it "returns not found" do
         expect(last_response).to be_not_found
+      end
+
+      it "returns error with the span" do
+        expect(event["error"]).to eq "ActionController::RoutingError"
+      end
+
+      it "returns error details with the span" do
+        expect(event["error_detail"]).to eq 'No route matches [GET] "/unrecognized"'
       end
 
       include_examples "the rails integration" do

--- a/spec/honeycomb/integrations/rails_spec.rb
+++ b/spec/honeycomb/integrations/rails_spec.rb
@@ -140,23 +140,30 @@ if defined?(Honeycomb::Rails)
         it "returns bad request" do
           expect(last_response).to be_bad_request
         end
+
+        it "returns an invalid request status code" do
+          expect(event["response.status_code"]).to eq 400
+        end
+
+        it "returns error with the span" do
+          expect(event["error"]).to eq "ActionController::BadRequest"
+        end
+
+        if VERSION >= Gem::Version.new("5.1")
+          it "returns error details with the span" do
+            expect(event["error_detail"])
+              .to eq "Invalid query parameters: Invalid encoding for parameter: �" # rubocop:disable Metrics/LineLength
+          end
+        else
+          it "returns error details with the span" do
+            expect(event["error_detail"])
+              .to eq "Invalid query parameters: Non UTF-8 value: \xC1"
+          end
+        end
       else
         it "returns ok" do
           expect(last_response).to be_ok
         end
-      end
-
-      it "returns an invalid request status code" do
-        expect(event["response.status_code"]).to eq 400
-      end
-
-      it "returns error with the span" do
-        expect(event["error"]).to eq "ActionController::BadRequest"
-      end
-
-      it "returns error details with the span" do
-        expect(event["error_detail"])
-          .to eq "Invalid query parameters: Invalid encoding for parameter: �"
       end
 
       include_examples "the rails integration" do


### PR DESCRIPTION
With #153 merged, this addresses the TODO comments left from adding tests for the events generated from error responses in #132.

Also adds a few more tests for the `error` and `error_details` fields that are the candy-like center of this effort to capture the details of errors in Rails.