### PR TITLE
Prepare 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # beeline-ruby changelog
 
+## 2.5.0 2021-07-16
+
+### Added
+
+- Allow backtrace to be sent with errors (#160) | [@lirossarvet](https://github.com/lirossarvet)
+
+### Maintenance
+
+- Updates Github Action Workflows (#159) | [@bdarfler](https://github.com/bdarfler)
+- Adds dependabot label (#158) | [@bdarfler](https://github.com/bdarfler)
+- Switches CODEOWNERS to telemetry-team (#157) | [@bdarfler](https://github.com/bdarfler)
+
 ## 2.4.2 2021-06-25
 
 ### Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    honeycomb-beeline (2.4.2)
+    honeycomb-beeline (2.5.0)
       libhoney (~> 1.14, >= 1.14.2)
 
 GEM

--- a/lib/honeycomb/beeline/version.rb
+++ b/lib/honeycomb/beeline/version.rb
@@ -3,7 +3,7 @@
 module Honeycomb
   module Beeline
     NAME = "honeycomb-beeline".freeze
-    VERSION = "2.4.2".freeze
+    VERSION = "2.5.0".freeze
     USER_AGENT_SUFFIX = "#{NAME}/#{VERSION}".freeze
   end
 end


### PR DESCRIPTION
Updates library version to `2.5.0` and adds changelog entry.