### PR TITLE
normalize ActiveSupport::Notification exceptions into error / error_d…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Exclude:
+    - spec/honeycomb/integrations/active_support_spec.rb
     - spec/support/event_data_shared_examples.rb
 
 Metrics/ParameterLists:

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -50,6 +50,13 @@ module Honeycomb
             # Make ActionController::Parameters parseable by libhoney.
             value = value.to_unsafe_hash if value.respond_to?(:to_unsafe_hash)
             span.add_field("#{name}.#{key}", value)
+
+            error, error_detail = payload[:exception]
+
+            if error
+              span.add_field("error", error)
+              span.add_field("error_detail", error_detail)
+            end
           end
         end
       end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -52,11 +52,12 @@ module Honeycomb
             span.add_field("#{name}.#{key}", value)
           end
 
-          exception_object = payload[:exception_object]
-          next unless exception_object
-
-          span.add_field("error", exception_object.class.to_s)
-          span.add_field("error_detail", exception_object.message)
+          # If the notification event has recorded an exception, add the
+          # Beeline's usual error fields to the span.
+          if payload[:exception_object]
+            span.add_field("error", payload[:exception_object].class.to_s)
+            span.add_field("error_detail", payload[:exception_object].message)
+          end
         end
       end
     end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -50,13 +50,12 @@ module Honeycomb
             # Make ActionController::Parameters parseable by libhoney.
             value = value.to_unsafe_hash if value.respond_to?(:to_unsafe_hash)
             span.add_field("#{name}.#{key}", value)
+          end
 
-            error, error_detail = payload[:exception]
-
-            if error
-              span.add_field("error", error)
-              span.add_field("error_detail", error_detail)
-            end
+          error, error_detail = payload[:exception]
+          if error
+            span.add_field("error", error)
+            span.add_field("error_detail", error_detail)
           end
         end
       end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -54,10 +54,12 @@ module Honeycomb
 
           # If the notification event has recorded an exception, add the
           # Beeline's usual error fields to the span.
-          if payload[:exception_object]
-            span.add_field("error", payload[:exception_object].class.to_s)
-            span.add_field("error_detail", payload[:exception_object].message)
-          end
+          # * Uses the 2-element array on :exception in the event payload
+          #   to support Rails 4. If Rails 4 support is dropped, consider
+          #   the :exception_object added in Rails 5.
+          error, error_detail = payload[:exception]
+          span.add_field("error", error) if error
+          span.add_field("error_detail", error_detail) if error_detail
         end
       end
     end

--- a/lib/honeycomb/integrations/active_support.rb
+++ b/lib/honeycomb/integrations/active_support.rb
@@ -52,11 +52,11 @@ module Honeycomb
             span.add_field("#{name}.#{key}", value)
           end
 
-          error, error_detail = payload[:exception]
-          if error
-            span.add_field("error", error)
-            span.add_field("error_detail", error_detail)
-          end
+          exception_object = payload[:exception_object]
+          next unless exception_object
+
+          span.add_field("error", exception_object.class.to_s)
+          span.add_field("error_detail", exception_object.message)
         end
       end
     end

--- a/spec/honeycomb/integrations/active_support_spec.rb
+++ b/spec/honeycomb/integrations/active_support_spec.rb
@@ -53,7 +53,6 @@ if defined?(Honeycomb::ActiveSupport)
           it_behaves_like "event data", package_fields: false, additional_fields: [
             "some.cool_event.is_this_going_to_error?",
             "some.cool_event.exception",
-            "some.cool_event.exception_object",
             "error",
             "error_detail",
           ]

--- a/spec/support/event_data_shared_examples.rb
+++ b/spec/support/event_data_shared_examples.rb
@@ -38,6 +38,12 @@ HTTP_FIELDS = %w[
 
 RSpec.shared_examples "event data" do |package_fields: true, http_fields: false, additional_fields: []|
   describe "data" do
+    it "is present" do
+      # .all? on an Enumerable like event_data will return true when the collection is empty.
+      # Confirm here that there are events to test.
+      expect(event_data).not_to be_empty
+    end
+
     BASE_FIELDS.each do |field|
       it "includes #{field}" do
         expect(event_data).to all(include field)


### PR DESCRIPTION
## Which problem is this PR solving?
There was a discussion in the [`#sdk-ruby`](https://honeycombpollinators.slack.com/archives/CJR134U2F/p1630081866001300)  channel regarding `ActiveSupport::Notification` payloads normalizing the `payload[:exception]` similarly to the way that other integrations in the beeline by setting `"error"` and `"error_detail"` on the span.

Making this consistent will assist in querying traces that might contain exceptions.

## Short description of the changes
* handle when a `payload[:exception]` exists by adding:
  * `error` - the exception class
  * `error_detail` - the exception message

One decision that I was not clear about was what to do about the existing information on the payload. This means that if you have an event such at `"muh.custom.thing"` and an error occurrs, you will have this:

```json
{
  "muh.custom.thing.exception": ["StandardError", "I tried, but I have failed"],
  "error": "StandardError",
  "error_detail": "I tried, but I have failed"
}
```

My thoughts regarding this were to leave it untouched, so as to not break any expectations.

