### PR TITLE
add Ruby 3.0 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,8 @@ workflows:
                 gemfile: rails_51
               - ruby-version: "3.0"
                 gemfile: rails_52
+              - ruby-version: "3.0"
+                gemfile: sequel4
 
   beeline:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,17 @@ workflows:
                 gemfile: rails_41
               - ruby-version: "2.7"
                 gemfile: rails_42
+              - ruby-version: "3.0"
+                gemfile: rails_41
+              - ruby-version: "3.0"
+                gemfile: rails_42
+              - ruby-version: "3.0"
+                gemfile: rails_5
+              - ruby-version: "3.0"
+                gemfile: rails_51
+              - ruby-version: "3.0"
+                gemfile: rails_52
+
   beeline:
     jobs:
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ workflows:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
               gemfile:
                 - aws_2
                 - aws_3

--- a/Appraisals
+++ b/Appraisals
@@ -2,6 +2,7 @@
 
 appraise "aws-2" do
   gem "aws-sdk", "~> 2"
+  gem "webrick"
 end
 
 appraise "aws-3" do

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/beeline-ruby)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![Build Status](https://circleci.com/gh/honeycombio/beeline-ruby.svg?style=svg)](https://circleci.com/gh/honeycombio/beeline-ruby)
 [![Gem Version](https://badge.fury.io/rb/honeycomb-beeline.svg)](https://badge.fury.io/rb/honeycomb-beeline)
-[![codecov](https://codecov.io/gh/honeycombio/beeline-ruby/branch/main/graph/badge.svg)](https://codecov.io/gh/honeycombio/beeline-ruby)
 
 This package makes it easy to instrument your Ruby web app to send useful events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 - [Usage and Examples](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/)

--- a/gemfiles/aws_2.gemfile
+++ b/gemfiles/aws_2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "aws-sdk", "~> 2"
+gem "webrick"
 
 gemspec path: "../"

--- a/lib/honeycomb/integrations/faraday.rb
+++ b/lib/honeycomb/integrations/faraday.rb
@@ -5,10 +5,11 @@ require "faraday"
 module Honeycomb
   # Faraday middleware to create spans around outgoing http requests
   class Faraday < ::Faraday::Middleware
-    def initialize(app, client:)
+    def initialize(app, options)
       super(app)
-      @client = client
+      @client = options[:client]
     end
+    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     def call(env)
       return @app.call(env) if @client.nil?

--- a/lib/honeycomb/integrations/faraday.rb
+++ b/lib/honeycomb/integrations/faraday.rb
@@ -9,7 +9,6 @@ module Honeycomb
       super(app)
       @client = options[:client]
     end
-    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     def call(env)
       return @app.call(env) if @client.nil?

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -30,7 +30,6 @@ module Honeycomb
       @app = app
       @client = options[:client]
     end
-    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     def call(env)
       req = ::Rack::Request.new(env)

--- a/lib/honeycomb/integrations/rack.rb
+++ b/lib/honeycomb/integrations/rack.rb
@@ -26,10 +26,11 @@ module Honeycomb
 
     attr_reader :app, :client
 
-    def initialize(app, client:)
+    def initialize(app, options)
       @app = app
-      @client = client
+      @client = options[:client]
     end
+    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     def call(env)
       req = ::Rack::Request.new(env)


### PR DESCRIPTION
## Which problem is this PR solving?

- The absence of testing the latest version of Ruby.

## Short description of the changes

- Easiest to walk the commits, starting with [the first](https://github.com/honeycombio/beeline-ruby/pull/171/commits/e5fb055ef74fecc1e2a06356791007d19744e533). Each commit message describes a discrete fix for adding Ruby 3.0 to the matrix.

