### PR TITLE
fix: new redis gem version broke tests

### DIFF
--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -2054,7 +2054,13 @@ if defined?(Honeycomb::Redis)
 
         let(:redis) do
           allow(connection).to receive(:read).and_return(slots, nodes, commands)
-          Redis.new(driver: driver, cluster: cluster, replica: true).tap do
+          Redis.new(
+            driver: driver, cluster: cluster, replica: true,
+          ).tap do |redis|
+            # https://github.com/redis/redis-rb/issues/1017
+            # establishes connections to all nodes in the cluster,
+            # otherwise extra READONLY commands are executed on replicas
+            redis.auth
             libhoney_client.events.clear
           end
         end

--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -2057,9 +2057,9 @@ if defined?(Honeycomb::Redis)
           Redis.new(
             driver: driver, cluster: cluster, replica: true,
           ).tap do |redis|
-            # https://github.com/redis/redis-rb/issues/1017
-            # establishes connections to all nodes in the cluster,
+            # Establishes connections to all nodes in the cluster,
             # otherwise extra READONLY commands are executed on replicas
+            # due to https://github.com/redis/redis-rb/issues/1017
             if VERSION > Gem::Version.new("4.1.1")
               redis.auth
             else

--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -2060,7 +2060,11 @@ if defined?(Honeycomb::Redis)
             # https://github.com/redis/redis-rb/issues/1017
             # establishes connections to all nodes in the cluster,
             # otherwise extra READONLY commands are executed on replicas
-            redis.auth
+            if VERSION > Gem::Version.new("4.1.1")
+              redis.auth
+            else
+              redis.auth("")
+            end
             libhoney_client.events.clear
           end
         end

--- a/spec/honeycomb/integrations/redis_spec.rb
+++ b/spec/honeycomb/integrations/redis_spec.rb
@@ -2060,11 +2060,7 @@ if defined?(Honeycomb::Redis)
             # Establishes connections to all nodes in the cluster,
             # otherwise extra READONLY commands are executed on replicas
             # due to https://github.com/redis/redis-rb/issues/1017
-            if VERSION > Gem::Version.new("4.1.1")
-              redis.auth
-            else
-              redis.auth("")
-            end
+            redis.auth("password")
             libhoney_client.events.clear
           end
         end


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- redis gem update includes additional READONLY commands being executed in cluster mode, which results in additional events generated by the beeline
- fixes #177 

## Short description of the changes

- decided to keep the tests specific and create a new IF branch for the newer versions of the gem

