### PR TITLE
feat: accept both w3c and honeycomb propagation headers by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Style/AccessModifierDeclarations:
     - lib/honeycomb/propagation/aws.rb
     - lib/honeycomb/propagation/w3c.rb
     - lib/honeycomb/propagation/honeycomb.rb
+    - lib/honeycomb/propagation/default.rb
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "socket"
-require "honeycomb/propagation/honeycomb"
+require "honeycomb/propagation/default"
 
 module Honeycomb
   # Used to configure the Honeycomb client
@@ -75,7 +75,7 @@ module Honeycomb
         @http_trace_parser_hook
       else
         # by default we try to parse incoming honeycomb traces
-        HoneycombPropagation::UnmarshalTraceContext.method(:parse_rack_env)
+        DefaultPropagation::UnmarshalTraceContext.method(:parse_rack_env)
       end
     end
 

--- a/lib/honeycomb/propagation/default.rb
+++ b/lib/honeycomb/propagation/default.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "honeycomb/propagation/honeycomb"
+require "honeycomb/propagation/w3c"
+
+module Honeycomb
+  # Default behavior for handling trace propagation
+  module DefaultPropagation
+    # Parse incoming trace headers.
+    #
+    # Checks for and parses Honeycomb's trace header or, if not found,
+    # then checks for and parses W3C trace parent header.
+    module UnmarshalTraceContext
+      def parse_rack_env(env)
+        if env["HTTP_X_HONEYCOMB_TRACE"]
+          HoneycombPropagation::UnmarshalTraceContext.parse_rack_env env
+        elsif env["HTTP_TRACEPARENT"]
+          W3CPropagation::UnmarshalTraceContext.parse_rack_env env
+        else
+          [nil, nil, nil, nil]
+        end
+      end
+      module_function :parse_rack_env
+      public :parse_rack_env
+    end
+  end
+end

--- a/spec/honeycomb/propagation/default_spec.rb
+++ b/spec/honeycomb/propagation/default_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "honeycomb/propagation/default"
+
+RSpec.describe Honeycomb::DefaultPropagation::UnmarshalTraceContext do
+  let(:parent_id) { SecureRandom.hex(8) }
+  let(:dataset) { "dataset" }
+  let(:trace_id) { SecureRandom.hex(16) }
+  let(:builder) { instance_double("Builder", dataset: dataset) }
+  let(:fields) { {} }
+  let(:trace) { instance_double("Trace", id: trace_id, fields: fields) }
+
+  let(:honeycomb_span) do
+    instance_double("Span", id: parent_id, trace: trace, builder: builder)
+      .extend(Honeycomb::PropagationSerializer)
+  end
+
+  let(:w3c_span) do
+    instance_double("Span", id: parent_id, trace: trace, builder: builder)
+      .extend(Honeycomb::W3CPropagation::MarshalTraceContext)
+  end
+
+  let(:default_propagation) { Class.new.extend(described_class) }
+
+  describe "handles an incoming span from a Honeycomb trace" do
+    let(:fields) do
+      { "test" => "honeycomb" }
+    end
+
+    let(:rack_env) do
+      { "HTTP_X_HONEYCOMB_TRACE" => honeycomb_span.to_trace_header }
+    end
+    let(:output) do
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "produces the correct fields" do
+      expect(output[2]).to eq fields
+    end
+
+    it "produces the correct dataset" do
+      expect(output[3]).to eq dataset
+    end
+  end
+
+  describe "handles an incoming span from a W3C trace" do
+    let(:rack_env) do
+      { "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
+    end
+    let(:output) do
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "returns nil fields" do
+      expect(output[2]).to eq nil
+    end
+
+    it "returns nil dataset" do
+      expect(output[3]).to eq nil
+    end
+  end
+
+  describe "prefers Honeycomb trace header over W3C when both are present" do
+    let(:fields) do
+      { "test" => "honeycomb" }
+    end
+
+    let(:rack_env) do
+      { "HTTP_X_HONEYCOMB_TRACE" => honeycomb_span.to_trace_header,
+        "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
+    end
+    let(:output) do
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "produces the correct fields" do
+      expect(output[2]).to eq fields
+    end
+
+    it "produces the correct dataset" do
+      expect(output[3]).to eq dataset
+    end
+  end
+end

--- a/spec/honeycomb/propagation/default_spec.rb
+++ b/spec/honeycomb/propagation/default_spec.rb
@@ -30,7 +30,16 @@ RSpec.describe Honeycomb::DefaultPropagation::UnmarshalTraceContext do
     let(:rack_env) do
       { "HTTP_X_HONEYCOMB_TRACE" => honeycomb_span.to_trace_header }
     end
+
     let(:output) do
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::HoneycombPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
       default_propagation.parse_rack_env(rack_env)
     end
 
@@ -56,6 +65,14 @@ RSpec.describe Honeycomb::DefaultPropagation::UnmarshalTraceContext do
       { "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
     end
     let(:output) do
+      expect(Honeycomb::HoneycombPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
       default_propagation.parse_rack_env(rack_env)
     end
 
@@ -86,6 +103,14 @@ RSpec.describe Honeycomb::DefaultPropagation::UnmarshalTraceContext do
         "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
     end
     let(:output) do
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::HoneycombPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
       default_propagation.parse_rack_env(rack_env)
     end
 


### PR DESCRIPTION
## Which problem is this PR solving?

Closes https://github.com/honeycombio/beeline-ruby/issues/180

## Short description of the changes

This is a very simple replacement incoming trace parent propagator hook. It will by default process either a Honeycomb or a W3C trace propagation header. If both are present, which we expect will be a very unusual case, the hook will prefer the Honeycomb trace header.

## TODO

- [x] integration test, probably with example greeting service
