### PR TITLE
[dev] set minimum version of rspec_junit_formatter

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug", "~> 3.6.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec_junit_formatter"
+  spec.add_development_dependency "rspec_junit_formatter", ">= 0.5.1"
   spec.add_development_dependency "rubocop", "< 0.69"
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #186 

## Short description of the changes

- 0.5.0 introduced a change that doesn't work in Ruby 2.2. 0.5.1 reverted that change and subsequent releases will include a minimum Ruby version of 2.3. This version constraint should carry us while we've got our current broad Ruby version test matrix.

