### PR TITLE
fix Beeline user-agent addition when creating a Libhoney client

### DIFF
--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -93,11 +93,13 @@ module Honeycomb
     private
 
     def libhoney_client_options
-      {}.tap do |o|
-        o[:writekey] = write_key
-        o[:dataset] = dataset
-        api_host && o[:api_host] = api_host
-        o[:user_agent_addition] = Honeycomb::Beeline::USER_AGENT_SUFFIX
+      {
+        writekey: write_key,
+        dataset: dataset,
+        user_agent_addition: Honeycomb::Beeline::USER_AGENT_SUFFIX,
+      }.tap do |options|
+        # only set the API host for the client if one has been given
+        options[:api_host] = api_host if api_host
       end
     end
   end

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -32,15 +32,15 @@ module Honeycomb
     end
 
     def client
-      options = {}.tap do |o|
-        o[:writekey] = write_key
-        o[:dataset] = dataset
-        api_host && o[:api_host] = api_host
-      end
-
-      @client ||
-        (debug && Libhoney::LogClient.new) ||
-        Libhoney::Client.new(**options)
+      # memoized:
+      # either the user has supplied a pre-configured Libhoney client
+      @client ||=
+        # or we'll create one and return it from here on
+        if debug
+          Libhoney::LogClient.new
+        else
+          Libhoney::Client.new(**libhoney_client_options)
+        end
     end
 
     def after_initialize(client)
@@ -87,6 +87,17 @@ module Honeycomb
       else
         # by default we send outgoing honeycomb trace headers
         HoneycombPropagation::MarshalTraceContext.method(:parse_faraday_env)
+      end
+    end
+
+    private
+
+    def libhoney_client_options
+      {}.tap do |o|
+        o[:writekey] = write_key
+        o[:dataset] = dataset
+        api_host && o[:api_host] = api_host
+        o[:user_agent_addition] = Honeycomb::Beeline::USER_AGENT_SUFFIX
       end
     end
   end


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #187 

## Short description of the changes

Use the Libhoney's public API for setting a user-agent-addition during client instantiation. This leaves in place the existing behavior—[a race to munge a private instance variable between client instantiation and sending the first event](https://github.com/honeycombio/beeline-ruby/blob/v2.8.0/lib/honeycomb/client.rb#L19-L23)—to keep the Beeline adding its version info to Libhoney versions prior to v1.19.0. I expect we'll remove that munging in a future major version bump that moves the libhoney dependency to v2.0+ and drops support for older Rubies.

