### PR TITLE
Remove the upperbound on libhoney version

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "libhoney", ">= 1.14.2", "~> 1.14"
+  spec.add_dependency "libhoney", ">= 1.14.2"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bump"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We have a pessimistic version guard on libhoney that prevents us from using 2.x. We should remove it.

## Short description of the changes
- Removes dependency guard of libhoney