### PR TITLE
Fix regression with mid vs leaf meta.span_type detection

### DIFF
--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -71,7 +71,6 @@ module Honeycomb
                      presend_hook: presend_hook,
                      propagation_hook: propagation_hook).tap do |c|
         children << c
-        @is_parent = true
       end
     end
 
@@ -133,10 +132,6 @@ module Honeycomb
       @is_root
     end
 
-    def parent?
-      @is_parent
-    end
-
     def send_internal
       add_additional_fields
       send_children
@@ -185,10 +180,10 @@ module Honeycomb
     def span_type
       if root?
         parent_id.nil? ? "root" : "subroot"
-      elsif parent?
-        "mid"
-      else
+      elsif children.empty?
         "leaf"
+      else
+        "mid"
       end
     end
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -71,6 +71,7 @@ module Honeycomb
                      presend_hook: presend_hook,
                      propagation_hook: propagation_hook).tap do |c|
         children << c
+        @is_parent = true
       end
     end
 
@@ -132,6 +133,10 @@ module Honeycomb
       @is_root
     end
 
+    def parent?
+      @is_parent
+    end
+
     def send_internal
       add_additional_fields
       send_children
@@ -180,10 +185,10 @@ module Honeycomb
     def span_type
       if root?
         parent_id.nil? ? "root" : "subroot"
-      elsif children.empty?
-        "leaf"
-      else
+      elsif parent?
         "mid"
+      else
+        "leaf"
       end
     end
 

--- a/lib/honeycomb/span.rb
+++ b/lib/honeycomb/span.rb
@@ -50,6 +50,7 @@ module Honeycomb
       # compatability
       @parent_id = parent_id
       @is_root = is_root
+      @is_leaf = true
     end
 
     def parse_hooks(sample_hook: nil,
@@ -71,7 +72,7 @@ module Honeycomb
                      presend_hook: presend_hook,
                      propagation_hook: propagation_hook).tap do |c|
         children << c
-        @is_parent = true
+        @is_leaf = false
       end
     end
 
@@ -133,8 +134,8 @@ module Honeycomb
       @is_root
     end
 
-    def parent?
-      @is_parent
+    def leaf?
+      @is_leaf
     end
 
     def send_internal
@@ -185,10 +186,10 @@ module Honeycomb
     def span_type
       if root?
         parent_id.nil? ? "root" : "subroot"
-      elsif parent?
-        "mid"
-      else
+      elsif leaf?
         "leaf"
+      else
+        "mid"
       end
     end
 


### PR DESCRIPTION
A regression was introduced by #98 in computing the `meta.span_type` field.

The field's value is given by the `Honeycomb::Span#span_type` method: https://github.com/honeycombio/beeline-ruby/blob/8b36cd0c94aba9378b6b0d74c9b593fc3f2bac0e/lib/honeycomb/span.rb#L180-L188

This field gets added as the span is being sent: https://github.com/honeycombio/beeline-ruby/blob/8b36cd0c94aba9378b6b0d74c9b593fc3f2bac0e/lib/honeycomb/span.rb#L159

For "mid" spans, this amounts to checking the `Honeycomb::Span#children` array at send-time. Prior to #98, this array would be full all the time, as no values were ever removed. However, #98 added this line at the end of `#send_internal`: https://github.com/honeycombio/beeline-ruby/blob/8b36cd0c94aba9378b6b0d74c9b593fc3f2bac0e/lib/honeycomb/span.rb#L152

So if all of a mid span's children are sent before the mid (which is typical of synchronous traces), its `#children` array will be empty at send-time, yielding an erroneous `#span_type` of "leaf".

This is captured by running the new regression tests from this PR against the old code:

```console
$ rspec spec/honeycomb/client_spec.rb:324 spec/honeycomb/client_spec.rb:350
Run options: include {:locations=>{"./spec/honeycomb/client_spec.rb"=>[324, 350]}}

Honeycomb::Client
  meta.span_type
    when children are sent before parents
      has the right values (FAILED - 1)
    when parents are sent before children
      has the right values

Failures:

  1) Honeycomb::Client meta.span_type when children are sent before parents has the right values
     Failure/Error: expect(mid["meta.span_type"]).to eq("mid")

       expected: "mid"
            got: "leaf"

       (compared using ==)
     # ./spec/honeycomb/client_spec.rb:342:in `block (5 levels) in <top (required)>'
     # ./spec/honeycomb/client_spec.rb:337:in `block (4 levels) in <top (required)>'

Finished in 0.01316 seconds (files took 0.69551 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/honeycomb/client_spec.rb:335 # Honeycomb::Client meta.span_type when children are sent before parents has the right values
```

We of course still want to clear out the `#children` array to avoid leaking memory. So the fix here is to toggle a sticky bit from `Honeycomb::Span#create_child`. If a child ever gets added to a span, even if it's removed later, we'll flip the `#span_type` from "leaf" to "mid". The "root"/"subroot" distinction still takes precedence over "mid".

The naming here for `Honeycomb::Span#parent?` might be a little confusing: it's saying that the span *is* a parent, not that it *has* a parent. But naming it `#mid?` isn't accurate, due to the possibility of it being a root/subroot. And something like `#has_children?` is confusing if the `#children` array is empty. I'm open to suggestions.