### PR TITLE
Add Environment and Services support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,6 @@ workflows:
           matrix:
             parameters:
               ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
-              ruby-version: ["2.4"]
               gemfile:
                 - aws_2
                 - aws_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,26 +148,26 @@ workflows:
             - lint
           matrix:
             parameters:
-              # ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
+              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
               ruby-version: ["2.4"]
               gemfile:
-                # - aws_2
-                # - aws_3
-                # - faraday_0
-                # - faraday_1
-                # - sequel4
-                # - sequel5
-                # - sinatra
-                # - rack
-                # - rails_41
-                # - rails_42
+                - aws_2
+                - aws_3
+                - faraday_0
+                - faraday_1
+                - sequel4
+                - sequel5
+                - sinatra
+                - rack
+                - rails_41
+                - rails_42
                 - rails_5
-                # - rails_51
-                # - rails_52
-                # - rails_6
-                # - rails_61
-                # - redis_3
-                # - redis_4
+                - rails_51
+                - rails_52
+                - rails_6
+                - rails_61
+                - redis_3
+                - redis_4
             exclude:
               - ruby-version: "2.2"
                 gemfile: faraday_1
@@ -210,10 +210,10 @@ workflows:
 
   beeline:
     jobs:
-      - lint:
-          filters: &regular_filters
-              tags:
-                only: /.*/
+      # - lint:
+      #     filters: &regular_filters
+      #         tags:
+      #           only: /.*/
       - test:
           <<: *test
           filters: *regular_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,25 +148,26 @@ workflows:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
+              # ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
+              ruby-version: ["2.4"]
               gemfile:
-                - aws_2
-                - aws_3
-                - faraday_0
-                - faraday_1
-                - sequel4
-                - sequel5
-                - sinatra
-                - rack
-                - rails_41
-                - rails_42
+                # - aws_2
+                # - aws_3
+                # - faraday_0
+                # - faraday_1
+                # - sequel4
+                # - sequel5
+                # - sinatra
+                # - rack
+                # - rails_41
+                # - rails_42
                 - rails_5
-                - rails_51
-                - rails_52
-                - rails_6
-                - rails_61
-                - redis_3
-                - redis_4
+                # - rails_51
+                # - rails_52
+                # - rails_6
+                # - rails_61
+                # - redis_3
+                # - redis_4
             exclude:
               - ruby-version: "2.2"
                 gemfile: faraday_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,10 +210,10 @@ workflows:
 
   beeline:
     jobs:
-      # - lint:
-      #     filters: &regular_filters
-      #         tags:
-      #           only: /.*/
+      - lint:
+          filters: &regular_filters
+              tags:
+                only: /.*/
       - test:
           <<: *test
           filters: *regular_filters

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/MethodLength:
     - lib/generators/honeycomb/honeycomb_generator.rb
 
 Metrics/LineLength:
+  Max: 100
   Exclude:
     - spec/honeycomb/integrations/active_support_spec.rb
     - spec/support/event_data_shared_examples.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,6 @@ Metrics/MethodLength:
     - lib/generators/honeycomb/honeycomb_generator.rb
 
 Metrics/LineLength:
-  Max: 100
   Exclude:
     - spec/honeycomb/integrations/active_support_spec.rb
     - spec/support/event_data_shared_examples.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/MethodLength:
     - lib/generators/honeycomb/honeycomb_generator.rb
 
 Metrics/LineLength:
+  Max: 100
   Exclude:
     - spec/honeycomb/integrations/active_support_spec.rb
     - spec/support/event_data_shared_examples.rb
@@ -71,3 +72,6 @@ Style/AsciiComments:
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method
+
+Style/IfUnlessModifier:
+  Enabled: false

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -12,6 +12,7 @@ class HoneycombGenerator < Rails::Generators::Base
   argument :write_key, required: true, desc: "required"
 
   class_option :dataset, type: :string, default: "rails"
+  class_option :service_name, type: :string, default: "rails"
 
   gem "honeycomb-beeline"
 
@@ -22,7 +23,13 @@ class HoneycombGenerator < Rails::Generators::Base
       <<-RUBY.strip_heredoc
         Honeycomb.configure do |config|
           config.write_key = #{write_key.inspect}
-          config.dataset = #{options['dataset'].inspect}
+          def classic?
+            config.write_key.nil || config.write_key.length == 32
+          end
+          if classic?
+            config.dataset = #{options['dataset'].inspect}
+          else
+            config.dataset = #{options['service_name'].inspect}
           config.presend_hook do |fields|
             if fields["name"] == "redis" && fields.has_key?("redis.command")
               # remove potential PII from the redis command

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -23,10 +23,7 @@ class HoneycombGenerator < Rails::Generators::Base
       <<-RUBY.strip_heredoc
         Honeycomb.configure do |config|
           config.write_key = #{write_key.inspect}
-          # def classic?
-          # config.write_key.nil? || config.write_key.length == 32
           classic = config.write_key.nil? || config.write_key.length == 32
-          # end
           if classic
             config.dataset = #{options['dataset'].inspect}
           else

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -23,10 +23,11 @@ class HoneycombGenerator < Rails::Generators::Base
       <<-RUBY.strip_heredoc
         Honeycomb.configure do |config|
           config.write_key = #{write_key.inspect}
-          def classic?
-            config.write_key.nil? || config.write_key.length == 32
-          end
-          if classic?
+          # def classic?
+          # config.write_key.nil? || config.write_key.length == 32
+          classic = config.write_key.nil? || config.write_key.length == 32
+          # end
+          if classic
             config.dataset = #{options['dataset'].inspect}
           else
             config.dataset = #{options['service_name'].inspect}

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -24,7 +24,7 @@ class HoneycombGenerator < Rails::Generators::Base
         Honeycomb.configure do |config|
           config.write_key = #{write_key.inspect}
           def classic?
-            config.write_key.nil || config.write_key.length == 32
+            config.write_key.nil? || config.write_key.length == 32
           end
           if classic?
             config.dataset = #{options['dataset'].inspect}

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -11,7 +11,6 @@ class HoneycombGenerator < Rails::Generators::Base
 
   argument :write_key, required: true, desc: "required"
 
-  class_option :dataset, type: :string, default: "rails"
   class_option :service_name, type: :string, default: "rails"
 
   gem "honeycomb-beeline"
@@ -23,12 +22,7 @@ class HoneycombGenerator < Rails::Generators::Base
       <<-RUBY.strip_heredoc
         Honeycomb.configure do |config|
           config.write_key = #{write_key.inspect}
-          classic = config.write_key.nil? || config.write_key.length == 32
-          if classic
-            config.dataset = #{options['dataset'].inspect}
-          else
-            config.dataset = #{options['service_name'].inspect}
-          end
+          config.service_name = #{options['service_name'].inspect}
           config.presend_hook do |fields|
             if fields["name"] == "redis" && fields.has_key?("redis.command")
               # remove potential PII from the redis command

--- a/lib/generators/honeycomb/honeycomb_generator.rb
+++ b/lib/generators/honeycomb/honeycomb_generator.rb
@@ -30,6 +30,7 @@ class HoneycombGenerator < Rails::Generators::Base
             config.dataset = #{options['dataset'].inspect}
           else
             config.dataset = #{options['service_name'].inspect}
+          end
           config.presend_hook do |fields|
             if fields["name"] == "redis" && fields.has_key?("redis.command")
               # remove potential PII from the redis command

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -4,7 +4,6 @@ require "forwardable"
 require "honeycomb/beeline/version"
 require "honeycomb/configuration"
 require "honeycomb/context"
-require "honeycomb/propagation/context"
 
 module Honeycomb
   # The Honeycomb Beeline client

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -30,6 +30,7 @@ module Honeycomb
 
       # maybe make `service_name` a required parameter
       @libhoney.add_field "service_name", configuration.service_name
+      @libhoney.add_field "service.name", configuration.service_name
       @context = Context.new
 
       @context.classic = classic_write_key?(configuration.write_key)

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -4,6 +4,7 @@ require "forwardable"
 require "honeycomb/beeline/version"
 require "honeycomb/configuration"
 require "honeycomb/context"
+require "honeycomb/propagation/context"
 
 module Honeycomb
   # The Honeycomb Beeline client
@@ -31,6 +32,8 @@ module Honeycomb
       # maybe make `service_name` a required parameter
       @libhoney.add_field "service_name", configuration.service_name
       @context = Context.new
+
+      @context.classic = classic_write_key?(configuration.write_key)
 
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,
@@ -124,6 +127,10 @@ module Honeycomb
       )
       span.add_field("error_backtrace_limit", error_backtrace_limit)
       span.add_field("error_backtrace_total_length", exception.backtrace.length)
+    end
+
+    def classic_write_key?(write_key)
+      write_key.nil? || write_key.length == 32
     end
   end
 end

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -144,8 +144,8 @@ module Honeycomb
     end
 
     def validate_options_classic
-      warn("empty service_name option") if !service_name_given?
-      warn("empty dataset option") if !dataset_given?
+      warn("empty service_name option") unless service_name_given?
+      warn("empty dataset option") unless dataset_given?
     end
 
     def service_name_given?

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -2,6 +2,7 @@
 
 require "socket"
 require "honeycomb/propagation/default"
+require "honeycomb/propagation/default_modern"
 
 module Honeycomb
   # Used to configure the Honeycomb client
@@ -96,9 +97,11 @@ module Honeycomb
         @http_trace_parser_hook = hook
       elsif @http_trace_parser_hook
         @http_trace_parser_hook
+      elsif classic?
+        DefaultPropagation::UnmarshalTraceContext.method(:parse_rack_env)
       else
         # by default we try to parse incoming honeycomb traces
-        DefaultPropagation::UnmarshalTraceContext.method(:parse_rack_env)
+        DefaultModernPropagation::UnmarshalTraceContext.method(:parse_rack_env)
       end
     end
 
@@ -107,9 +110,11 @@ module Honeycomb
         @http_trace_propagation_hook = hook
       elsif @http_trace_propagation_hook
         @http_trace_propagation_hook
+      elsif classic?
+        HoneycombPropagation::MarshalTraceContext.method(:parse_faraday_env)
       else
         # by default we send outgoing honeycomb trace headers
-        HoneycombPropagation::MarshalTraceContext.method(:parse_faraday_env)
+        HoneycombModernPropagation::MarshalTraceContext.method(:parse_faraday_env)
       end
     end
 

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -22,8 +22,8 @@ module Honeycomb
       @client = nil
     end
 
-    def is_classic(write_key)
-      write_key.length == 32
+    def is_classic
+      @write_key.length == 32
     end
 
     def service_name

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -22,27 +22,31 @@ module Honeycomb
       @client = nil
     end
 
-    def is_classic
+    def classic
       @write_key.nil? || @write_key.length == 32
     end
 
     def service_name
       if @service_name.nil? || @service_name.empty?
-        is_classic ?
-          @dataset :
-          "unknown_service:" + $0.split("/").last # append script name (eg rspec, script.rb, etc)
+        if classic
+          @dataset
+        else
+          # append script name (eg rspec, script.rb, etc)
+          "unknown_service:" + $PROGRAM_NAME.split("/").last
+        end
       else
         @service_name
       end
     end
 
     def dataset
-      if is_classic
+      if classic
         @dataset
+      elsif service_name.strip.start_with?("unknown_service")
+        # don't use process name in dataset
+        "unknown_service"
       else
-        service_name.strip.start_with?("unknown_service") ?
-          "unknown_service" : # don't use process name in dataset
-          service_name.strip
+        service_name.strip
       end
     end
 

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -22,6 +22,10 @@ module Honeycomb
       @client = nil
     end
 
+    def is_classic(write_key)
+      write_key.length == 32
+    end
+
     def service_name
       @service_name || dataset
     end

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -22,13 +22,13 @@ module Honeycomb
       @client = nil
     end
 
-    def classic
+    def classic?
       @write_key.nil? || @write_key.length == 32
     end
 
     def service_name
       if @service_name.nil? || @service_name.empty?
-        if classic
+        if classic?
           @dataset
         else
           # append script name (eg rspec, script.rb, etc)
@@ -40,7 +40,7 @@ module Honeycomb
     end
 
     def dataset
-      if classic
+      if classic?
         @dataset
       elsif service_name.strip.start_with?("unknown_service")
         # don't use process name in dataset

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -30,7 +30,7 @@ module Honeycomb
       if @service_name.nil? || @service_name.empty?
         is_classic ?
           @dataset :
-          "unknown_service:" + $0.split("/").last
+          "unknown_service:" + $0.split("/").last # append script name (eg rspec, script.rb, etc)
       else
         @service_name
       end
@@ -41,7 +41,7 @@ module Honeycomb
         @dataset
       else
         service_name.strip.start_with?("unknown_service") ?
-          "unknown_service" :
+          "unknown_service" : # don't use process name in dataset
           service_name.strip
       end
     end

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -7,11 +7,10 @@ module Honeycomb
   # Used to configure the Honeycomb client
   class Configuration
     attr_accessor :write_key,
-                  :dataset,
                   :api_host,
                   :debug
 
-    attr_writer :service_name, :client, :host_name
+    attr_writer :service_name, :client, :host_name, :dataset
     attr_reader :error_backtrace_limit
 
     def initialize
@@ -25,6 +24,10 @@ module Honeycomb
 
     def service_name
       @service_name || dataset
+    end
+
+    def dataset
+      @dataset
     end
 
     def error_backtrace_limit=(val)

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -31,7 +31,11 @@ module Honeycomb
     end
 
     def dataset
-      @dataset
+      if @dataset.nil? || @dataset.empty?
+        "unknown_service"
+      else
+        @dataset
+      end
     end
 
     def error_backtrace_limit=(val)

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -37,9 +37,13 @@ module Honeycomb
     end
 
     def dataset
-      is_classic ?
-        @dataset :
-        service_name.strip
+      if is_classic
+        @dataset
+      else
+        service_name.strip.start_with?("unknown_service") ?
+          "unknown_service" :
+          service_name.strip
+      end
     end
 
     def error_backtrace_limit=(val)

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -23,11 +23,17 @@ module Honeycomb
     end
 
     def is_classic
-      @write_key.length == 32
+      @write_key.nil? || @write_key.length == 32
     end
 
     def service_name
-      @service_name || dataset
+      if @service_name.nil? || @service_name.empty?
+        is_classic ?
+          "unknown_service:" + $0.split("/").last :
+          @dataset
+      else
+        @service_name
+      end
     end
 
     def dataset

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -29,19 +29,17 @@ module Honeycomb
     def service_name
       if @service_name.nil? || @service_name.empty?
         is_classic ?
-          "unknown_service:" + $0.split("/").last :
-          @dataset
+          @dataset :
+          "unknown_service:" + $0.split("/").last
       else
         @service_name
       end
     end
 
     def dataset
-      if @dataset.nil? || @dataset.empty?
-        "unknown_service"
-      else
-        @dataset
-      end
+      is_classic ?
+        @dataset :
+        service_name.strip
     end
 
     def error_backtrace_limit=(val)

--- a/lib/honeycomb/context.rb
+++ b/lib/honeycomb/context.rb
@@ -3,6 +3,7 @@
 module Honeycomb
   # Stores the current span and trace context
   class Context
+    attr_writer :classic
     def current_trace
       return if current_span.nil?
 
@@ -21,6 +22,10 @@ module Honeycomb
       spans.last != span && raise(ArgumentError, "Incorrect span sent")
 
       spans.pop
+    end
+
+    def classic?
+      !!@classic
     end
 
     private

--- a/lib/honeycomb/context.rb
+++ b/lib/honeycomb/context.rb
@@ -24,9 +24,11 @@ module Honeycomb
       spans.pop
     end
 
+    # rubocop:disable Style/DoubleNegation
     def classic?
       !!@classic
     end
+    # rubocop:enable Style/DoubleNegation
 
     private
 

--- a/lib/honeycomb/context.rb
+++ b/lib/honeycomb/context.rb
@@ -24,11 +24,9 @@ module Honeycomb
       spans.pop
     end
 
-    # rubocop:disable Style/DoubleNegation
     def classic?
-      !!@classic
+      @classic
     end
-    # rubocop:enable Style/DoubleNegation
 
     private
 

--- a/lib/honeycomb/propagation/default_modern.rb
+++ b/lib/honeycomb/propagation/default_modern.rb
@@ -20,8 +20,10 @@ module Honeycomb
           [nil, nil, nil, nil]
         end
       end
+      # rubocop:disable Style/AccessModifierDeclarations
       module_function :parse_rack_env
       public :parse_rack_env
+      # rubocop:enable Style/AccessModifierDeclarations
     end
   end
 end

--- a/lib/honeycomb/propagation/default_modern.rb
+++ b/lib/honeycomb/propagation/default_modern.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "honeycomb/propagation/honeycomb_modern"
+require "honeycomb/propagation/w3c"
+
+module Honeycomb
+  # Default behavior for handling trace propagation
+  module DefaultModernPropagation
+    # Parse incoming trace headers.
+    #
+    # Checks for and parses Honeycomb's trace header or, if not found,
+    # then checks for and parses W3C trace parent header.
+    module UnmarshalTraceContext
+      def parse_rack_env(env)
+        if env["HTTP_X_HONEYCOMB_TRACE"]
+          HoneycombModernPropagation::UnmarshalTraceContext.parse_rack_env env
+        elsif env["HTTP_TRACEPARENT"]
+          W3CPropagation::UnmarshalTraceContext.parse_rack_env env
+        else
+          [nil, nil, nil, nil]
+        end
+      end
+      module_function :parse_rack_env
+      public :parse_rack_env
+    end
+  end
+end

--- a/lib/honeycomb/propagation/honeycomb_modern.rb
+++ b/lib/honeycomb/propagation/honeycomb_modern.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "uri"
+
+module Honeycomb
+  # Parsing and propagation for honeycomb trace headers
+  module HoneycombModernPropagation
+    # Parse trace headers
+    module UnmarshalTraceContext
+      def parse_rack_env(env)
+        parse env["HTTP_X_HONEYCOMB_TRACE"]
+      end
+
+      def parse(serialized_trace)
+        unless serialized_trace.nil?
+          version, payload = serialized_trace.split(";", 2)
+
+          if version == "1"
+            trace_id, parent_span_id, trace_fields = parse_v1(payload)
+
+            if !trace_id.nil? && !parent_span_id.nil?
+              return [trace_id, parent_span_id, trace_fields, nil]
+            end
+          end
+        end
+
+        [nil, nil, nil, nil]
+      end
+
+      def parse_v1(payload)
+        trace_id, parent_span_id, trace_fields = nil
+        payload.split(",").each do |entry|
+          key, value = entry.split("=", 2)
+          case key.downcase
+          when "trace_id"
+            trace_id = value
+          when "parent_id"
+            parent_span_id = value
+          when "context"
+            Base64.decode64(value).tap do |json|
+              begin
+                trace_fields = JSON.parse json
+              rescue JSON::ParserError
+                trace_fields = {}
+              end
+            end
+          end
+        end
+
+        [trace_id, parent_span_id, trace_fields, nil]
+      end
+
+      module_function :parse_rack_env, :parse, :parse_v1
+      public :parse_rack_env, :parse
+    end
+
+    # Serialize trace headers
+    module MarshalTraceContext
+      def to_trace_header
+        context = Base64.urlsafe_encode64(JSON.generate(trace.fields)).strip
+        data_to_propogate = [
+          "trace_id=#{trace.id}",
+          "parent_id=#{id}",
+          "context=#{context}",
+        ]
+        "1;#{data_to_propogate.join(',')}"
+      end
+
+      def self.parse_faraday_env(_env, propagation_context)
+        {
+          "X-Honeycomb-Trace" => to_trace_header(propagation_context),
+        }
+      end
+
+      def self.to_trace_header(propagation_context)
+        fields = propagation_context.trace_fields
+        context = Base64.urlsafe_encode64(JSON.generate(fields)).strip
+        data_to_propogate = [
+          "trace_id=#{propagation_context.trace_id}",
+          "parent_id=#{propagation_context.parent_id}",
+          "context=#{context}",
+        ]
+        "1;#{data_to_propogate.join(',')}"
+      end
+    end
+  end
+end

--- a/lib/honeycomb/propagation/w3c.rb
+++ b/lib/honeycomb/propagation/w3c.rb
@@ -31,12 +31,8 @@ module Honeycomb
       def parse_v1(payload)
         trace_id, parent_span_id, trace_flags = payload.split("-", 3)
 
-        if trace_flags.nil?
-          # if trace_flags is nil, it means a field is missing
-          return [nil, nil]
-        end
-
-        if trace_id == INVALID_TRACE_ID || parent_span_id == INVALID_SPAN_ID
+        # if trace_flags is nil, it means a field is missing
+        if trace_flags.nil? || trace_id == INVALID_TRACE_ID || parent_span_id == INVALID_SPAN_ID
           return [nil, nil]
         end
 

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -5,11 +5,13 @@ require "securerandom"
 require "honeycomb/span"
 require "honeycomb/propagation"
 require "honeycomb/rollup_fields"
+require "honeycomb/configuration"
 
 module Honeycomb
   # Represents a Honeycomb trace, which groups spans together
   class Trace
-    include PropagationParser
+    # include PropagationParser
+
     include RollupFields
     extend Forwardable
 
@@ -19,9 +21,14 @@ module Honeycomb
 
     def initialize(builder:, context:, serialized_trace: nil, **options)
       trace_id, parent_span_id, trace_fields, dataset =
-        internal_parse(serialized_trace: serialized_trace, **options)
+        internal_parse(context: context, serialized_trace: serialized_trace, **options)
 
-      dataset && builder.dataset = dataset
+      # if dataset is not nil,
+      # set trace's builder.dataset = dataset from trace header
+      if context.classic?
+        dataset && builder.dataset = dataset
+      end
+
       @id = trace_id || generate_trace_id
       @fields = trace_fields || {}
       @root_span = Span.new(trace: self,
@@ -47,15 +54,17 @@ module Honeycomb
       end
     end
 
-    def internal_parse(serialized_trace: nil, parser_hook: nil, **_options)
+    def internal_parse(context:, serialized_trace: nil, parser_hook: nil, **_options)
       # previously we passed in the header directly as a string for us to parse
       # now we get passed the rack env to use as an argument to the provided
       # parser_hook. This preserves the current behaviour and allows us to
       # move forward with the new behaviour without breaking changes
       if serialized_trace.is_a?(Hash) && parser_hook
         parser_hook.call(serialized_trace)
+      elsif context.classic?
+        HoneycombPropagation::UnmarshalTraceContext.parse serialized_trace
       else
-        parse serialized_trace
+        HoneycombModernPropagation::UnmarshalTraceContext.parse serialized_trace
       end
     end
   end

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -9,8 +9,6 @@ require "honeycomb/rollup_fields"
 module Honeycomb
   # Represents a Honeycomb trace, which groups spans together
   class Trace
-    # include PropagationParser
-
     include RollupFields
     extend Forwardable
 

--- a/lib/honeycomb/trace.rb
+++ b/lib/honeycomb/trace.rb
@@ -5,7 +5,6 @@ require "securerandom"
 require "honeycomb/span"
 require "honeycomb/propagation"
 require "honeycomb/rollup_fields"
-require "honeycomb/configuration"
 
 module Honeycomb
   # Represents a Honeycomb trace, which groups spans together

--- a/spec/generators/honeycomb/honeycomb_generator_spec.rb
+++ b/spec/generators/honeycomb/honeycomb_generator_spec.rb
@@ -6,7 +6,8 @@ if defined?(Honeycomb::Rails)
   RSpec.describe HoneycombGenerator do
     describe "simple execution" do
       let(:name) { "honeycomb" }
-      let(:write_key) { "generator_write_key" }
+      # let(:write_key) { "generator_write_key" }
+      let(:write_key) { "classic_generator_write_key_test" }
       let(:dataset) { "generator_dataset" }
       let(:init_file) { File.join(@dir, "config/initializers/honeycomb.rb") }
       let(:config) { Honeycomb::Configuration.new }

--- a/spec/generators/honeycomb/honeycomb_generator_spec.rb
+++ b/spec/generators/honeycomb/honeycomb_generator_spec.rb
@@ -7,7 +7,7 @@ if defined?(Honeycomb::Rails)
     describe "simple execution" do
       let(:name) { "honeycomb" }
       let(:write_key) { "classic_generator_write_key_test" }
-      let(:dataset) { "generator_dataset" }
+      let(:service_name) { "a_service_name" }
       let(:init_file) { File.join(@dir, "config/initializers/honeycomb.rb") }
       let(:config) { Honeycomb::Configuration.new }
 
@@ -40,16 +40,16 @@ if defined?(Honeycomb::Rails)
           expect(config.write_key).to eq(write_key)
         end
 
-        it "sets the dataset to a default" do
+        it "sets the service_name to a default" do
           Rails::Generators.invoke(name, [write_key])
           require init_file
-          expect(config.dataset).not_to be_empty
+          expect(config.service_name).not_to be_empty
         end
 
-        it "sets the dataset correctly" do
-          Rails::Generators.invoke(name, [write_key, "--dataset", dataset])
+        it "sets the service_name correctly" do
+          Rails::Generators.invoke(name, [write_key, "--service_name", service_name])
           require init_file
-          expect(config.dataset).to eq(dataset)
+          expect(config.service_name).to eq(service_name)
         end
 
         it "sets the notification events" do

--- a/spec/generators/honeycomb/honeycomb_generator_spec.rb
+++ b/spec/generators/honeycomb/honeycomb_generator_spec.rb
@@ -6,7 +6,6 @@ if defined?(Honeycomb::Rails)
   RSpec.describe HoneycombGenerator do
     describe "simple execution" do
       let(:name) { "honeycomb" }
-      # let(:write_key) { "generator_write_key" }
       let(:write_key) { "classic_generator_write_key_test" }
       let(:dataset) { "generator_dataset" }
       let(:init_file) { File.join(@dir, "config/initializers/honeycomb.rb") }

--- a/spec/honeycomb/beeline_spec.rb
+++ b/spec/honeycomb/beeline_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Honeycomb do
   before do
     Honeycomb.configure do |config|
       config.write_key = "write_key"
-      config.dataset = "dataset"
-      config.service_name = "service_name"
+      config.dataset = "a_dataset"
+      config.service_name = "a_service_name"
       config.client = libhoney_client
     end
   end
@@ -51,11 +51,12 @@ RSpec.describe Honeycomb do
 
     it "contains service_name field" do
       expect(libhoney_client.events.map(&:data))
-        .to all(include("service.name" => "service_name"))
+        .to all(include("service_name" => "a_service_name"))
     end
+
     it "contains service.name field" do
       expect(libhoney_client.events.map(&:data))
-        .to all(include("service.name" => "service_name"))
+        .to all(include("service.name" => "a_service_name"))
     end
   end
 

--- a/spec/honeycomb/beeline_spec.rb
+++ b/spec/honeycomb/beeline_spec.rb
@@ -42,6 +42,23 @@ RSpec.describe Honeycomb do
     end
   end
 
+  describe "service name configured" do
+    before do
+      Honeycomb.start_span(name: "test") do
+        Honeycomb.add_field_to_trace("interesting", "banana")
+      end
+    end
+
+    it "contains service_name field" do
+      expect(libhoney_client.events.map(&:data))
+        .to all(include("service.name" => "service_name"))
+    end
+    it "contains service.name field" do
+      expect(libhoney_client.events.map(&:data))
+        .to all(include("service.name" => "service_name"))
+    end
+  end
+
   describe "adding fields to span" do
     before do
       Honeycomb.start_span(name: "test") do

--- a/spec/honeycomb/client_spec.rb
+++ b/spec/honeycomb/client_spec.rb
@@ -187,12 +187,10 @@ RSpec.describe Honeycomb::Client do
         expect(data["error_backtrace_limit"]).to eq(error_backtrace_limit)
       end
 
-      # rubocop:disable Metrics/LineLength
       it "includes error_backtrace_total_length as the backtrace's original length" do
         data = event_data.first
         expect(data["error_backtrace_total_length"]).to eq(2)
       end
-      # rubocop:enable Metrics/LineLength
 
       it_behaves_like(
         "event data",
@@ -237,12 +235,10 @@ RSpec.describe Honeycomb::Client do
           expect(data["error_backtrace_limit"]).to eq(error_backtrace_limit)
         end
 
-        # rubocop:disable Metrics/LineLength
         it "includes error_backtrace_total_length as the backtrace's original length" do
           data = event_data.first
           expect(data["error_backtrace_total_length"]).to eq(5)
         end
-        # rubocop:enable Metrics/LineLength
 
         it_behaves_like(
           "event data",

--- a/spec/honeycomb/client_spec.rb
+++ b/spec/honeycomb/client_spec.rb
@@ -187,10 +187,12 @@ RSpec.describe Honeycomb::Client do
         expect(data["error_backtrace_limit"]).to eq(error_backtrace_limit)
       end
 
+      # rubocop:disable Metrics/LineLength
       it "includes error_backtrace_total_length as the backtrace's original length" do
         data = event_data.first
         expect(data["error_backtrace_total_length"]).to eq(2)
       end
+      # rubocop:enable Metrics/LineLength
 
       it_behaves_like(
         "event data",
@@ -235,10 +237,12 @@ RSpec.describe Honeycomb::Client do
           expect(data["error_backtrace_limit"]).to eq(error_backtrace_limit)
         end
 
+        # rubocop:disable Metrics/LineLength
         it "includes error_backtrace_total_length as the backtrace's original length" do
           data = event_data.first
           expect(data["error_backtrace_total_length"]).to eq(5)
         end
+        # rubocop:enable Metrics/LineLength
 
         it_behaves_like(
           "event data",

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe Honeycomb::Configuration do
   describe "non-classic API key defaults for" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
-      configuration.service_name = ""
     end
 
     it "service_name" do

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Honeycomb::Configuration do
   end
 
   it "has a default service_name" do
-    expect(configuration.service_name).to eq dataset_name
+    expect(configuration.service_name).to eq "unknown_service:rspec"
   end
 
   it "has the correct write_key" do

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -146,42 +146,6 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  describe "classic API key" do
-    before do
-      configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"
-      configuration.dataset = " dataset "
-      configuration.service_name = " my-service "
-    end
-
-    it "is_classic returns true" do
-      expect(configuration.is_classic).to eq true
-    end
-
-    it "service_name" do
-      expect(configuration.service_name).to eq " my-service "
-    end
-
-    it "dataset" do
-      expect(configuration.dataset).to eq " dataset "
-    end
-  end
-
-  describe "classic API key defaults" do 
-    before do
-      configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"
-      configuration.dataset = " dataset "
-      configuration.service_name = " my-service "
-    end
-
-    it "service_name" do
-      expect(configuration.service_name).to eq " my-service "
-    end
-
-    it "dataset" do
-      expect(configuration.dataset).to eq " dataset "
-    end
-  end
-
   describe "non-classic API key" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Honeycomb::Configuration do
   let(:configuration) { Honeycomb::Configuration.new }
-  let(:write_key) { "d68f9ed1e96432ac1a3380" }
+  let(:write_key) { "not_a_classic_write_key" }
   let(:api_host) { "https://www.honeycomb.io" }
   let(:event) { configuration.client.event }
 

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -157,7 +157,8 @@ RSpec.describe Honeycomb::Configuration do
     end
 
     describe "default behavior" do
-      it "given no service name, service_name returns unknown_servce:<program_name>" do
+      it "given no service name, " \
+         "service_name returns unknown_servce:<program_name>" do
         expect(configuration.service_name).to eq "unknown_service:rspec"
       end
 

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -152,20 +152,12 @@ RSpec.describe Honeycomb::Configuration do
       configuration.service_name = " my-service "
     end
 
-    it "is_classic returns false" do
-      expect(configuration.is_classic).to eq false
-    end
-
-    it "service_name" do
-      expect(configuration.service_name).to eq " my-service "
-    end
-
-    it "dataset" do
+    it "dataset returns trimmed service name" do
       expect(configuration.dataset).to eq "my-service"
     end
   end
 
-  describe "non-classic API key defaults" do 
+  describe "non-classic API key defaults for" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
       configuration.service_name = ""

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Honeycomb::Configuration do
   let(:configuration) { Honeycomb::Configuration.new }
   let(:dataset_name) { "dataset" }
   let(:service_name) { "service_name" }
-  let(:write_key) { "service_name" }
+  let(:write_key) { "e38be416d0d68f9ed1e96432ac1a3380" }
   let(:api_host) { "https://www.honeycomb.io" }
   let(:event) { configuration.client.event }
 

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -156,9 +156,13 @@ RSpec.describe Honeycomb::Configuration do
       expect(configuration.dataset).to eq "my-service"
     end
 
+    it "given a nil service name, dataset returns the dataset" do
+      expect(configuration.dataset).to eq "unknown_service"
+    end
+
     describe "default behavior" do
       it "given no service name, " \
-         "service_name returns unknown_servce:<program_name>" do
+        "service_name returns unknown_servce:<program_name>" do
         expect(configuration.service_name).to eq "unknown_service:rspec"
       end
 

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  describe "non-classic API key" do 
+  describe "non-classic API key" do
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
       configuration.service_name = " my-service "
@@ -157,7 +157,7 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  describe "non-classic API key defaults for" do 
+  describe "non-classic API key defaults for" do
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
     end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Honeycomb::Configuration do
   end
 
   it "has a default service_name" do
-    expect(configuration.service_name).to eq "unknown_service:rspec"
+    expect(configuration.service_name).to eq dataset_name
   end
 
   it "has the correct write_key" do
@@ -146,16 +146,6 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  describe "empty dataset defaults" do
-    before do
-      configuration.dataset = ""
-    end
-
-    it "returns default" do
-      expect(configuration.dataset).to eq "unknown_service"
-    end
-  end
-
   describe "classic API key" do
     before do
       configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"
@@ -166,17 +156,33 @@ RSpec.describe Honeycomb::Configuration do
     it "is_classic returns true" do
       expect(configuration.is_classic).to eq true
     end
+
+    it "service_name" do
+      expect(configuration.service_name).to eq " my-service "
+    end
+
+    it "dataset" do
+      expect(configuration.dataset).to eq " dataset "
+    end
   end
 
   describe "non-classic API key" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
-      configuration.dataset = " dataset "
+      configuration.dataset = "dataset"
       configuration.service_name = " my-service "
     end
 
     it "is_classic returns false" do
       expect(configuration.is_classic).to eq false
+    end
+
+    it "service_name" do
+      expect(configuration.service_name).to eq " my-service "
+    end
+
+    it "dataset" do
+      expect(configuration.dataset).to eq "my-service"
     end
   end
 end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -146,28 +146,24 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  describe "non-classic API key" do
+  describe "with a non-classic write key" do
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
-      configuration.service_name = " my-service "
     end
 
-    it "dataset returns trimmed service name" do
+    it "given a service name, dataset returns a trimmed service name" do
+      configuration.service_name = " my-service "
       expect(configuration.dataset).to eq "my-service"
     end
-  end
 
-  describe "non-classic API key defaults for" do
-    before do
-      configuration.write_key = "d68f9ed1e96432ac1a3380"
-    end
+    describe "default behavior" do
+      it "given no service name, service_name returns unknown_servce:<program_name>" do
+        expect(configuration.service_name).to eq "unknown_service:rspec"
+      end
 
-    it "service_name" do
-      expect(configuration.service_name).to eq "unknown_service:rspec"
-    end
-
-    it "dataset" do
-      expect(configuration.dataset).to eq "unknown_service"
+      it "dataset returns trimmed service_name" do
+        expect(configuration.dataset).to eq "unknown_service"
+      end
     end
   end
 end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -166,10 +166,25 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
+  describe "classic API key defaults" do 
+    before do
+      configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"
+      configuration.dataset = " dataset "
+      configuration.service_name = " my-service "
+    end
+
+    it "service_name" do
+      expect(configuration.service_name).to eq " my-service "
+    end
+
+    it "dataset" do
+      expect(configuration.dataset).to eq " dataset "
+    end
+  end
+
   describe "non-classic API key" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
-      configuration.dataset = "dataset"
       configuration.service_name = " my-service "
     end
 
@@ -183,6 +198,21 @@ RSpec.describe Honeycomb::Configuration do
 
     it "dataset" do
       expect(configuration.dataset).to eq "my-service"
+    end
+  end
+
+  describe "non-classic API key defaults" do 
+    before do
+      configuration.write_key = "d68f9ed1e96432ac1a3380"
+      configuration.service_name = ""
+    end
+
+    it "service_name" do
+      expect(configuration.service_name).to eq "unknown_service:rspec"
+    end
+
+    it "dataset" do
+      expect(configuration.dataset).to eq "unknown_service"
     end
   end
 end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -2,15 +2,12 @@
 
 RSpec.describe Honeycomb::Configuration do
   let(:configuration) { Honeycomb::Configuration.new }
-  let(:dataset_name) { "dataset" }
-  let(:service_name) { "service_name" }
-  let(:write_key) { "e38be416d0d68f9ed1e96432ac1a3380" }
+  let(:write_key) { "d68f9ed1e96432ac1a3380" }
   let(:api_host) { "https://www.honeycomb.io" }
   let(:event) { configuration.client.event }
 
   before do
     configuration.write_key = write_key
-    configuration.dataset = dataset_name
     configuration.api_host = api_host
     configuration.presend_hook do
     end
@@ -38,82 +35,156 @@ RSpec.describe Honeycomb::Configuration do
     expect(configuration.http_trace_propagation_hook).to respond_to(:call)
   end
 
-  it "has a default service_name" do
-    expect(configuration.service_name).to eq dataset_name
+  it "has the correct api_host" do
+    expect(configuration.api_host).to eq api_host
   end
 
   it "has the correct write_key" do
     expect(configuration.write_key).to eq write_key
   end
 
-  it "has the correct dataset" do
-    expect(configuration.dataset).to eq dataset_name
-  end
-
-  it "has the correct api_host" do
-    expect(configuration.api_host).to eq api_host
-  end
-
-  it "has a Libhoney client by default" do
-    expect(configuration.client).to be_a Libhoney::Client
-  end
-
-  it "has a client with Beeline version information in the user agent" do
-    libhoney_client = configuration.client
-    transmission = libhoney_client.instance_variable_get(:@transmission)
-    user_agent = transmission.instance_variable_get(:@user_agent)
-    expect(user_agent).to match(Honeycomb::Beeline::USER_AGENT_SUFFIX)
-  end
-
-  context "when debug is enabled" do
-    before do
-      configuration.debug = true
+  describe "#service_name" do
+    it "returns the default unknown-service:<process_name> when not set" do
+      # rspec is the expected process name because *this test suite* is rspec
+      expect(configuration.service_name).to eq "unknown_service:rspec"
     end
 
-    it "has a logging Libhoney" do
-      expect(configuration.client).to be_a Libhoney::LogClient
+    it "returns a set service name" do
+      configuration.service_name = "awesome_sauce"
+      expect(configuration.service_name).to eq "awesome_sauce"
+    end
+
+    it "does not remove leading/trailing whitespace" do
+      configuration.service_name = "    spacey    "
+      expect(configuration.service_name).to eq "    spacey    "
+    end
+
+    context "with a classic write key" do
+      before do
+        configuration.write_key = "c1a551c000d68f9ed1e96432ac1a3380"
+      end
+
+      it "returns the value of dataset when service_name isn't set" do
+        configuration.dataset = "a_dataset"
+        expect(configuration.service_name).to eq "a_dataset"
+      end
     end
   end
 
-  context "when a customized Libhoney client is given in the config" do
-    before do
-      configuration.client = Libhoney::Client.new(
-        writekey: "customized!",
-        dataset: dataset_name,
-        proxy_config: "https://myproxy.example.com:8080",
-      )
+  describe "#dataset" do
+    it "is based on service_name, no longer set directly" do
+      configuration.service_name = "the_service_name"
+      configuration.dataset = "ignore_me"
+      expect do
+        expect(configuration.dataset).to eq "the_service_name"
+      end.to output(/dataset will be ignored/).to_stderr
     end
 
-    it "has the custom Libhoney as its client" do
-      expect(configuration.client.writekey).to eq "customized!"
-      proxy_config = configuration.client.instance_variable_get(:@proxy_config)
-      expect(proxy_config).not_to be_nil
+    it "removes leading/trailing whitespace to confusion in environments" do
+      configuration.service_name = "    spacey    "
+      expect do
+        expect(configuration.dataset).to eq "spacey"
+      end.to output("found extra whitespace in service name\n").to_stderr
     end
 
-    # This is known current behavior and consistent with what the other
-    # Beeline's do. It would be nice for the Beelines to be able to add
-    # their version info to  user-instantiated libhoney/transmissions,
-    # but that's not part of the libhoney public API at the moment. So
-    # this test exists to confirm the current behavior, even if that
-    # behavior is more incidental than intentional.
-    it "sadly, does not add Beeline version to the client user-agent" do
-      custom_client = configuration.client
-      transmission = custom_client.instance_variable_get(:@transmission)
+    context "defaults to 'unknown_service'" do
+      it "when service_name is not set" do
+        expect(configuration.dataset).to eq "unknown_service"
+      end
+
+      it "when service_name starts with but is longer than 'unknown_service'" do
+        configuration.service_name = "unknown_service:a_funky_long_process_name"
+        expect(configuration.dataset).to eq "unknown_service"
+      end
+
+      it "when service_name is only white space" do
+        configuration.service_name = "    "
+        expect do
+          expect(configuration.dataset).to eq "unknown_service"
+        end.to output("found extra whitespace in service name\n").to_stderr
+      end
+    end
+
+    context "with a classic write key" do
+      before do
+        configuration.write_key = "c1a551c000d68f9ed1e96432ac1a3380"
+      end
+
+      it "returns whatever dataset has been set" do
+        expect(configuration.dataset).to be_nil
+        configuration.dataset = "a_dataset"
+        expect(configuration.dataset).to eq "a_dataset"
+      end
+    end
+  end
+
+  describe "#client" do
+    let(:service_name) { "client_tests" }
+    let(:libhoney_client) do
+      configuration.service_name = service_name
+      configuration.client
+    end
+
+    it "has a Libhoney client by default" do
+      expect(libhoney_client).to be_a Libhoney::Client
+    end
+
+    it "produces with the correct write_key" do
+      expect(libhoney_client.event.writekey).to be write_key
+    end
+
+    it "configures the client with the correct dataset" do
+      expect(libhoney_client.event.dataset).to eq service_name
+    end
+
+    it "configures the client with the correct api_host" do
+      expect(libhoney_client.event.api_host).to be api_host
+    end
+
+    it "has a client with Beeline version information in the user agent" do
+      transmission = libhoney_client.instance_variable_get(:@transmission)
       user_agent = transmission.instance_variable_get(:@user_agent)
-      expect(user_agent).not_to match(Honeycomb::Beeline::USER_AGENT_SUFFIX)
+      expect(user_agent).to match(Honeycomb::Beeline::USER_AGENT_SUFFIX)
     end
-  end
 
-  it "configures the client with the correct write_key" do
-    expect(event.writekey).to be write_key
-  end
+    context "when debug is enabled" do
+      before do
+        configuration.debug = true
+      end
 
-  it "configures the client with the correct dataset" do
-    expect(event.dataset).to be dataset_name
-  end
+      it "has a logging Libhoney" do
+        expect(configuration.client).to be_a Libhoney::LogClient
+      end
+    end
 
-  it "configures the client with the correct api_host" do
-    expect(event.api_host).to be api_host
+    context "when a customized Libhoney client is given in the config" do
+      before do
+        configuration.client = Libhoney::Client.new(
+          writekey: "customized!",
+          dataset: "custom_dataset",
+          proxy_config: "https://myproxy.example.com:8080",
+        )
+      end
+
+      it "has the custom Libhoney as its client" do
+        expect(configuration.client.writekey).to eq "customized!"
+        proxy_config = configuration.client.instance_variable_get(:@proxy_config)
+        expect(proxy_config).not_to be_nil
+      end
+
+      # This is known current behavior and consistent with what the other
+      # Beeline's do. It would be nice for the Beelines to be able to add
+      # their version info to  user-instantiated libhoney/transmissions,
+      # but that's not part of the libhoney public API at the moment. So
+      # this test exists to confirm the current behavior, even if that
+      # behavior is more incidental than intentional.
+      it "sadly, does not add Beeline version to the client user-agent" do
+        custom_client = configuration.client
+        transmission = custom_client.instance_variable_get(:@transmission)
+        user_agent = transmission.instance_variable_get(:@user_agent)
+        expect(user_agent).not_to match(Honeycomb::Beeline::USER_AGENT_SUFFIX)
+      end
+    end
   end
 
   describe "error_backtrace_limit" do
@@ -132,42 +203,6 @@ RSpec.describe Honeycomb::Configuration do
         expect do
           configuration.error_backtrace_limit = nil
         end.to raise_error(TypeError)
-      end
-    end
-  end
-
-  describe "configured service_name" do
-    before do
-      configuration.service_name = service_name
-    end
-
-    it "uses the provided service_name" do
-      expect(configuration.service_name).to eq service_name
-    end
-  end
-
-  describe "with a non-classic write key" do
-    before do
-      configuration.write_key = "d68f9ed1e96432ac1a3380"
-    end
-
-    it "given a service name, dataset returns a trimmed service name" do
-      configuration.service_name = " my-service "
-      expect(configuration.dataset).to eq "my-service"
-    end
-
-    it "given a nil service name, dataset returns the dataset" do
-      expect(configuration.dataset).to eq "unknown_service"
-    end
-
-    describe "default behavior" do
-      it "given no service name, " \
-        "service_name returns unknown_servce:<program_name>" do
-        expect(configuration.service_name).to eq "unknown_service:rspec"
-      end
-
-      it "dataset returns trimmed service_name" do
-        expect(configuration.dataset).to eq "unknown_service"
       end
     end
   end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -75,9 +75,7 @@ RSpec.describe Honeycomb::Configuration do
     it "is based on service_name, no longer set directly" do
       configuration.service_name = "the_service_name"
       configuration.dataset = "ignore_me"
-      expect do
-        expect(configuration.dataset).to eq "the_service_name"
-      end.to output(/dataset will be ignored/).to_stderr
+      expect(configuration.dataset).to eq "the_service_name"
     end
 
     it "removes leading/trailing whitespace to confusion in environments" do

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -146,17 +146,26 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
-  it "has a classic API key" do
-    expect(configuration.is_classic).to eq true
+  describe "classic API key" do
+    before do
+      configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"
+      configuration.dataset = " dataset "
+      configuration.service_name = " my-service "
+    end
+
+    it "is_classic returns true" do
+      expect(configuration.is_classic).to eq true
+    end
   end
 
   describe "non-classic API key" do 
     before do
       configuration.write_key = "d68f9ed1e96432ac1a3380"
+      configuration.dataset = " dataset "
       configuration.service_name = " my-service "
     end
 
-    it "has a non-classic write key" do
+    it "is_classic returns false" do
       expect(configuration.is_classic).to eq false
     end
   end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -145,4 +145,19 @@ RSpec.describe Honeycomb::Configuration do
       expect(configuration.service_name).to eq service_name
     end
   end
+
+  it "has a classic API key" do
+    expect(configuration.is_classic).to eq true
+  end
+
+  describe "non-classic API key" do 
+    before do
+      configuration.write_key = "d68f9ed1e96432ac1a3380"
+      configuration.service_name = " my-service "
+    end
+
+    it "has a non-classic write key" do
+      expect(configuration.is_classic).to eq false
+    end
+  end
 end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -146,6 +146,16 @@ RSpec.describe Honeycomb::Configuration do
     end
   end
 
+  describe "empty dataset defaults" do
+    before do
+      configuration.dataset = ""
+    end
+
+    it "returns default" do
+      expect(configuration.dataset).to eq "unknown_service"
+    end
+  end
+
   describe "classic API key" do
     before do
       configuration.write_key = "e38be416d0d68f9ed1e96432ac1a3380"

--- a/spec/honeycomb/integrations/aws_spec.rb
+++ b/spec/honeycomb/integrations/aws_spec.rb
@@ -98,6 +98,7 @@ if defined?(Honeycomb::Aws)
         expect(sdk).to match(
           "name" => "aws-sdk",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => an_instance_of(String),
           "meta.span_type" => "root",
@@ -122,6 +123,7 @@ if defined?(Honeycomb::Aws)
         expect(api).to match(
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",
@@ -187,6 +189,7 @@ if defined?(Honeycomb::Aws)
         expect(sdk).to match(
           "name" => "aws-sdk",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => an_instance_of(String),
           "meta.span_type" => "root",
@@ -214,6 +217,7 @@ if defined?(Honeycomb::Aws)
         expect(api).to match(
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",
@@ -278,6 +282,7 @@ if defined?(Honeycomb::Aws)
         expect(sdk).to match(
           "name" => "aws-sdk",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => an_instance_of(String),
           "meta.span_type" => "root",
@@ -303,6 +308,7 @@ if defined?(Honeycomb::Aws)
         expect(api).to match(
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",
@@ -363,6 +369,7 @@ if defined?(Honeycomb::Aws)
         expect(sdk).to match(
           "name" => "aws-sdk",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => an_instance_of(String),
           "meta.span_type" => "root",
@@ -391,6 +398,7 @@ if defined?(Honeycomb::Aws)
         expect(api_failure).to match(
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",
@@ -427,6 +435,7 @@ if defined?(Honeycomb::Aws)
         expect(api_success).to match(
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",
@@ -502,6 +511,7 @@ if defined?(Honeycomb::Aws)
         expect(sdk).to match(
           "name" => "aws-sdk",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => an_instance_of(String),
           "meta.span_type" => "root",
@@ -529,6 +539,7 @@ if defined?(Honeycomb::Aws)
         {
           "name" => "aws-api",
           "service_name" => "example",
+          "service.name" => "example",
           "meta.beeline_version" => Honeycomb::Beeline::VERSION,
           "meta.local_hostname" => sdk["meta.local_hostname"],
           "meta.span_type" => "leaf",

--- a/spec/honeycomb/propagation/default_modern_spec.rb
+++ b/spec/honeycomb/propagation/default_modern_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "honeycomb/propagation/default_modern"
+
+RSpec.describe Honeycomb::DefaultModernPropagation::UnmarshalTraceContext do
+  let(:parent_id) { SecureRandom.hex(8) }
+  let(:dataset) { "dataset" }
+  let(:trace_id) { SecureRandom.hex(16) }
+  let(:builder) { instance_double("Builder", dataset: dataset) }
+  let(:fields) { {} }
+  let(:trace) { instance_double("Trace", id: trace_id, fields: fields) }
+
+  let(:honeycomb_span) do
+    instance_double("Span", id: parent_id, trace: trace, builder: builder)
+      .extend(Honeycomb::PropagationSerializer)
+  end
+
+  let(:w3c_span) do
+    instance_double("Span", id: parent_id, trace: trace, builder: builder)
+      .extend(Honeycomb::W3CPropagation::MarshalTraceContext)
+  end
+
+  let(:default_propagation) { Class.new.extend(described_class) }
+
+  describe "handles an incoming span from a Honeycomb trace" do
+    let(:fields) do
+      { "test" => "honeycomb" }
+    end
+
+    let(:rack_env) do
+      { "HTTP_X_HONEYCOMB_TRACE" => honeycomb_span.to_trace_header }
+    end
+
+    let(:output) do
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::HoneycombModernPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "produces the correct fields" do
+      expect(output[2]).to eq fields
+    end
+
+    it "does not include a dataset" do
+      expect(output[3]).to be_nil
+    end
+  end
+
+  describe "handles an incoming span from a W3C trace" do
+    let(:rack_env) do
+      { "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
+    end
+    let(:output) do
+      expect(Honeycomb::HoneycombModernPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "returns nil fields" do
+      expect(output[2]).to eq nil
+    end
+
+    it "returns nil dataset" do
+      expect(output[3]).to eq nil
+    end
+  end
+
+  describe "prefers Honeycomb trace header over W3C when both are present" do
+    let(:fields) do
+      { "test" => "honeycomb" }
+    end
+
+    let(:rack_env) do
+      { "HTTP_X_HONEYCOMB_TRACE" => honeycomb_span.to_trace_header,
+        "HTTP_TRACEPARENT" => w3c_span.to_trace_header }
+    end
+    let(:output) do
+      expect(Honeycomb::W3CPropagation::UnmarshalTraceContext)
+        .not_to receive(:parse_rack_env)
+
+      expect(Honeycomb::HoneycombModernPropagation::UnmarshalTraceContext)
+        .to receive(:parse_rack_env)
+        .with(rack_env)
+        .and_call_original
+
+      default_propagation.parse_rack_env(rack_env)
+    end
+
+    it "produces the correct trace_id" do
+      expect(output[0]).to eq trace_id
+    end
+
+    it "produces the correct parent_span_id" do
+      expect(output[1]).to eq parent_id
+    end
+
+    it "produces the correct fields" do
+      expect(output[2]).to eq fields
+    end
+
+    it "does not include a dataset" do
+      expect(output[3]).to be_nil
+    end
+  end
+end

--- a/spec/honeycomb/propagation/honeycomb_modern_spec.rb
+++ b/spec/honeycomb/propagation/honeycomb_modern_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "honeycomb/propagation/context"
+require "honeycomb/propagation/honeycomb_modern"
+
+RSpec.shared_examples "honeycomb_propagation_parse" do
+  it "handles a nil trace" do
+    expect(propagation.parse(nil)).to eq [nil, nil, nil, nil]
+  end
+
+  it "handles invalid string" do
+    expect(propagation.parse("test")).to eq [nil, nil, nil, nil]
+  end
+
+  it "handles only having trace id being specified" do
+    expect(propagation.parse("1;trace_id=1")).to eq [nil, nil, nil, nil]
+  end
+
+  it "handles only having parent span id being specified" do
+    expect(propagation.parse("1;parent_id=1")).to eq [nil, nil, nil, nil]
+  end
+
+  it "handles having trace and parent id specified" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id"
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      nil,
+      nil,
+    ]
+  end
+
+  it "ignores an incoming dataset" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id,dataset=dataset"
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      nil,
+      nil,
+    ]
+  end
+
+  it "handles parsing a context" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id,context=eyJ0ZXN0IjoxfQ=="
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      { "test" => 1 },
+      nil,
+    ]
+  end
+
+  it "handles parsing a context and ignores incoming dataset" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id,context=eyJ0ZXN0IjoxfQ==,dataset=ignoreme"
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      { "test" => 1 },
+      nil,
+    ]
+  end
+
+  it "handles invalid json" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id,context=dGVzdA=="
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      {},
+      nil,
+    ]
+  end
+end
+
+RSpec.describe Honeycomb::HoneycombModernPropagation::UnmarshalTraceContext do
+  let(:propagation) { Class.new.extend(subject) }
+
+  describe "module usage" do
+    let(:propagation) { Class.new.extend(subject) }
+    include_examples "honeycomb_propagation_parse"
+  end
+
+  describe "class method usage" do
+    let(:propagation) { subject }
+    include_examples "honeycomb_propagation_parse"
+  end
+end
+
+RSpec.describe Honeycomb::HoneycombModernPropagation::MarshalTraceContext do
+  describe "module usage" do
+    let(:builder) { instance_double("Builder", dataset: "rails") }
+    let(:trace) { instance_double("Trace", id: 2, fields: {}) }
+    let(:span) do
+      instance_double("Span", id: 1, trace: trace, builder: builder)
+        .extend(subject)
+    end
+
+    it "can serialize a basic span and not include the dataset" do
+      expect(span.to_trace_header)
+        .to eq("1;trace_id=2,parent_id=1,context=e30=")
+    end
+  end
+
+  describe "class method usage" do
+    let(:context) { Honeycomb::Propagation::Context.new(2, 1, {}, "rails") }
+
+    it "can serialize a basic span and not include the dataset" do
+      expect(subject.to_trace_header(context))
+        .to eq("1;trace_id=2,parent_id=1,context=e30=")
+    end
+  end
+end
+
+RSpec.describe "Propagation" do
+  let(:parent_id) { SecureRandom.hex(8) }
+  let(:dataset) { "rails,tesing/with-%characters%" }
+  let(:trace_id) { SecureRandom.hex(16) }
+  let(:fields) do
+    {
+      "test" => "honeycomb",
+    }
+  end
+  let(:builder) { instance_double("Builder", dataset: dataset) }
+  let(:trace) { instance_double("Trace", id: trace_id, fields: fields) }
+  let(:span) do
+    instance_double("Span", id: parent_id, trace: trace, builder: builder)
+      .extend(Honeycomb::PropagationSerializer)
+  end
+
+  let(:propagation) { Class.new.extend(Honeycomb::PropagationParser) }
+
+  let(:output) do
+    propagation.parse(span.to_trace_header)
+  end
+
+  it "produces the correct dataset" do
+    expect(output[3]).to eq dataset
+  end
+
+  it "produces the correct trace_id" do
+    expect(output[0]).to eq trace_id
+  end
+
+  it "produces the correct parent_span_id" do
+    expect(output[1]).to eq parent_id
+  end
+
+  it "produces the correct fields" do
+    expect(output[2]).to eq fields
+  end
+end

--- a/spec/honeycomb/trace_spec.rb
+++ b/spec/honeycomb/trace_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Honeycomb::Trace do
             ))
       .and_call_original
 
-    expect(context).not_to be_nil
-
     Honeycomb::Trace.new(
       builder: builder,
       context: context,

--- a/spec/honeycomb/trace_spec.rb
+++ b/spec/honeycomb/trace_spec.rb
@@ -2,9 +2,6 @@
 
 require "libhoney"
 
-## TODO testing dataset behavior in classic vs nonclassic
-## What dataset is on this tracer's builder?
-
 RSpec.describe Honeycomb::Trace do
   let(:libhoney_client) { Libhoney::TestClient.new }
   let(:context) { Honeycomb::Context.new }
@@ -33,7 +30,6 @@ RSpec.describe Honeycomb::Trace do
 end
 
 RSpec.describe Honeycomb::Trace do
-  # todo set dataset in libhoney builder
   let(:libhoney_client) { Libhoney::TestClient.new(dataset: "awesome") }
   let(:builder) { libhoney_client.builder }
 

--- a/spec/honeycomb/trace_spec.rb
+++ b/spec/honeycomb/trace_spec.rb
@@ -33,8 +33,10 @@ RSpec.describe Honeycomb::Trace do
   let(:libhoney_client) { Libhoney::TestClient.new(dataset: "awesome") }
   let(:builder) { libhoney_client.builder }
 
-  subject(:trace) { Honeycomb::Trace.new(builder: builder,
-                                        context: Honeycomb::Context.new) }
+  subject(:trace) do
+    Honeycomb::Trace.new(builder: builder,
+                         context: Honeycomb::Context.new)
+  end
 
   let(:trace_fields) { { "wow" => 420 } }
   let(:upstream_trace_header) { trace.root_span.to_trace_header }

--- a/spec/honeycomb/trace_spec.rb
+++ b/spec/honeycomb/trace_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Honeycomb::Trace do
 
   describe "distributed tracing" do
     describe "with a classic key" do
-      let(:context) { Honeycomb::Context.new.tap {|c| c.classic = true } }
+      let(:context) { Honeycomb::Context.new.tap { |c| c.classic = true } }
 
       it "context should be classic" do
         expect(context.classic?).to be true
@@ -83,7 +83,7 @@ RSpec.describe Honeycomb::Trace do
     end
 
     describe "with a modern key" do
-      let(:context) { Honeycomb::Context.new.tap {|c| c.classic = false } }
+      let(:context) { Honeycomb::Context.new.tap { |c| c.classic = false } }
       it "preserves the trace_id" do
         expect(distributed_trace.id).to eq trace.id
       end


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #193 

## Short description of the changes

If using an environment-aware key:
- dataset = serviceName
- add field of `service.name` in addition to `service_name` to be more consistent with otel
- use default service name of `unknown_service:<processname>` or `unknown_service:ruby` if process name is unavailable and no service name provided
- don't propagate dataset by default unless legacy key (to prevent overwriting of service name)
- warn on missing service name and api key
- warn on presence of dataset, noting data will be sent to service name
- if dataset derived from service name starts with `unknown_service*`, truncate to `unknown_service` for dataset
- if dataset derived from service name has extra whitespace, trim whitespace and console warn on diff

warning provided if dataset is set in config when using environment key: 
`dataset will be ignored, sending data to message-rb`
`service_name is unknown, will set to unknown_service:rackup`
`dataset will be ignored, sending data to unknown_service:rackup`

If using a classic key:
- dataset is dataset in config, no default set
- add field of `service.name` in addition to `service_name` to be more consistent with otel
- use default service name of `unknown_service:<processname>` or `unknown_service:go` if process name is unavailable and no service name provided
- dataset propagates by default
- warn on missing service name, api key, dataset

warning on missing env vars with classic key:
`empty service_name option`
`empty dataset option`
`Libhoney::Client: no dataset configured, disabling sending events`