### PR TITLE
Let Rake spans be disabled programmatically

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Metrics/BlockLength:
   Exclude:
     - honeycomb-beeline.gemspec
     - spec/**/*.rb
+    - spec/**/*.rake
 
 Metrics/AbcSize:
   Max: 50

--- a/lib/honeycomb-beeline.rb
+++ b/lib/honeycomb-beeline.rb
@@ -25,7 +25,7 @@ module Honeycomb
     extend Forwardable
     attr_reader :client
 
-    def_delegators :@client, :libhoney, :start_span, :add_field,
+    def_delegators :client, :libhoney, :start_span, :add_field,
                    :add_field_to_trace, :current_span, :current_trace,
                    :with_field, :with_trace_field
 

--- a/lib/honeycomb/integrations/rake.rb
+++ b/lib/honeycomb/integrations/rake.rb
@@ -35,7 +35,9 @@ module Honeycomb
       attr_writer :honeycomb_client
 
       def honeycomb_client
-        @honeycomb_client || Honeycomb.client
+        return @honeycomb_client if defined?(@honeycomb_client)
+
+        Honeycomb.client
       end
     end
   end

--- a/lib/honeycomb/integrations/rake.rb
+++ b/lib/honeycomb/integrations/rake.rb
@@ -22,7 +22,11 @@ module Honeycomb
         end
       end
 
+      attr_writer :honeycomb_client
+
       def honeycomb_client
+        return @honeycomb_client if defined?(@honeycomb_client)
+
         application.honeycomb_client
       end
     end

--- a/spec/honeycomb/integrations/rake_spec.rb
+++ b/spec/honeycomb/integrations/rake_spec.rb
@@ -2,28 +2,107 @@
 
 if defined?(Honeycomb::Rake)
   RSpec.describe Honeycomb::Rake do
-    let(:libhoney_client) { Libhoney::TestClient.new }
-    let(:event_data) { libhoney_client.events.map(&:data) }
-    let(:configuration) do
-      Honeycomb::Configuration.new.tap do |config|
-        config.client = libhoney_client
+    # Each example is run within an isolated Rake application.
+    around { |ex| Rake.with_application(&ex) }
+
+    # Each example loads the same shared Rakefile.
+    before { Rake.load_rakefile("spec/support/test_tasks.rake") }
+
+    let(:client) do
+      config = Honeycomb::Configuration.new
+      config.client = Libhoney::TestClient.new
+      Honeycomb::Client.new(configuration: config)
+    end
+
+    let(:custom) do
+      config = Honeycomb::Configuration.new
+      config.client = Libhoney::TestClient.new
+      Honeycomb::Client.new(configuration: config)
+    end
+
+    let(:event_data) { client.libhoney.events.map(&:data) }
+
+    context "when Honeycomb is not configured" do
+      before { allow(Honeycomb).to receive(:client).and_return(nil) }
+
+      it "does not send event data" do
+        expect { Rake::Task["test:event_data"].invoke }.not_to raise_error
+        expect(event_data).to be_empty
+      end
+
+      it "can use a custom Honeycomb client" do
+        Rake.application.honeycomb_client = custom
+        Rake::Task["test:event_data"].invoke
+        expect(custom.libhoney.events).not_to be_empty
       end
     end
-    let(:client) { Honeycomb::Client.new(configuration: configuration) }
 
-    before do
-      other_rake = Rake.with_application do |app|
-        app.add_import "spec/support/test_tasks.rake"
-        app.load_rakefile
+    context "when Honeycomb is configured" do
+      before { allow(Honeycomb).to receive(:client).and_return(client) }
+
+      it_behaves_like "event data" do
+        before { Rake::Task["test:event_data"].invoke }
       end
-      other_rake.honeycomb_client = client
-      other_rake.invoke_task("test:perform")
-    end
 
-    it "sends the two events" do
-      expect(libhoney_client.events.size).to eq 2
-    end
+      it "sets the name field" do
+        Rake::Task["test:name"].invoke
+        expect(event_data.count).to be 1
+        aggregate_failures do
+          event = event_data.first
+          expect(event).to include("name" => "rake.test:name")
+          expect(event).not_to include("rake.description", "rake.arguments")
+        end
+      end
 
-    it_behaves_like "event data"
+      it "sets the rake.description field" do
+        Rake::Task["test:description"].invoke
+        expect(event_data.count).to be 1
+        aggregate_failures do
+          event = event_data.first
+          expect(event).to include(
+            "name" => "rake.test:description",
+            "rake.description" => "this is a description",
+          )
+          expect(event).not_to include("rake.arguments")
+        end
+      end
+
+      it "sets the rake.arguments field" do
+        Rake::Task["test:arguments"].invoke(1, 2, 3)
+        expect(event_data.count).to be 1
+        aggregate_failures do
+          event = event_data.first
+          expect(event).to include(
+            "name" => "rake.test:arguments",
+            "rake.arguments" => "[a,b,c]",
+          )
+          expect(event).not_to include("rake.description")
+        end
+      end
+
+      it "gives the task access to the Honeycomb client" do
+        Rake::Task["test:honeycomb_client"].invoke
+        names = event_data.map { |event| event["name"] }
+        expect(names).to eq ["inner task span", "rake.test:honeycomb_client"]
+      end
+
+      it "can be disabled" do
+        Rake.application.honeycomb_client = nil
+        Rake::Task["test:disabled"].invoke
+        names = event_data.map { |event| event["name"] }
+        expect(names).to eq ["global honeycomb client is still enabled"]
+      end
+
+      it "can use a custom Honeycomb client" do
+        Rake.application.honeycomb_client = custom
+        Rake::Task["test:custom"].invoke
+        aggregate_failures do
+          custom_names = custom.libhoney.events.map { |event| event.data["name"] }
+          expect(custom_names).to eq ["using custom honeycomb client", "rake.test:custom"]
+          global_names = client.libhoney.events.map { |event| event.data["name"] }
+          expect(global_names).to eq ["using global honeycomb client"]
+        end
+      end
+    end
   end
 end

--- a/spec/support/test_tasks.rake
+++ b/spec/support/test_tasks.rake
@@ -10,20 +10,21 @@ namespace :test do
 
   task :arguments, %i[a b c]
 
-  task :honeycomb_client do |t|
-    t.honeycomb_client.start_span(name: "inner task span") do
-      :ok
+  namespace :client do
+    task :access do |t|
+      t.honeycomb_client.start_span(name: "inner task span") { :ok }
     end
-  end
 
-  task :disabled do
-    Honeycomb.start_span(name: "global honeycomb client is still enabled") do
-      :ok
+    task :enabled
+
+    task disabled: :enabled do
+      Honeycomb.start_span(name: "global honeycomb client is still enabled") { :ok }
     end
-  end
 
-  task :custom do |t|
-    t.honeycomb_client.start_span(name: "using custom honeycomb client") { :ok }
-    Honeycomb.start_span(name: "using global honeycomb client") { :ok }
+    task :default do
+      Honeycomb.start_span(name: "global honeycomb client") { :ok } if Honeycomb.client
+    end
+
+    task custom: :default
   end
 end

--- a/spec/support/test_tasks.rake
+++ b/spec/support/test_tasks.rake
@@ -1,10 +1,29 @@
 # frozen_string_literal: true
 
 namespace :test do
-  desc "used by integration_spec to test rake integration"
-  task :perform do |task|
-    task.honeycomb_client.start_span(name: "inner task span") do
-      # nothing to do here...
+  task :event_data
+
+  task :name
+
+  desc "this is a description"
+  task :description
+
+  task :arguments, %i[a b c]
+
+  task :honeycomb_client do |t|
+    t.honeycomb_client.start_span(name: "inner task span") do
+      :ok
     end
+  end
+
+  task :disabled do
+    Honeycomb.start_span(name: "global honeycomb client is still enabled") do
+      :ok
+    end
+  end
+
+  task :custom do |t|
+    t.honeycomb_client.start_span(name: "using custom honeycomb client") { :ok }
+    Honeycomb.start_span(name: "using global honeycomb client") { :ok }
   end
 end


### PR DESCRIPTION
## Which problem is this PR solving?

When running a Rake task, the Honeycomb integration typically creates the root node of the trace (since the task is the entry point into the program). For short-lived tasks like `rake db:migrate`, this works great. However, tasks might be long-lived. For example, `rake resque:work` [runs forever](https://github.com/resque/resque/blob/e068909cc0cbf1afa2fa4cb33be2809a397ce9d3/README.markdown#running-workers), dequeueing background jobs on a loop. Ideally, we'd like a separate trace for each job that gets dequeued. But with the Rake integration enabled, all the jobs' traces point back up at the auto-generated root span, which will be missing until the worker process finally dies. This has been discussed before in Pollinators: https://honeycombpollinators.slack.com/archives/CJR134U2F/p1643989199035879

As-is, the only way to disable the Rake integration is to remove it from the `HONEYCOMB_INTEGRATIONS` env var. There's a bug in the implementation of `Rake::Application#honeycomb_client` such that setting it to `nil` doesn't disable the Rake tracing (same sort of bug as in #60). Moreover, we can't pick & choose which Rake tasks generate a span. So if we disable the Rake integration altogether, `rake resque:work` might look good, but something like `rake db:migrate` will just generate a bunch of orphans that can't be tied back to a single parent.

This PR allows you to programmatically disable the Rake integration both on the application level and the individual task level.

## Short description of the changes

- Fixed bug in `Rake::Application#honeycomb_client` so that it will honor when we set it to `nil`.
- Modified `Rake::Task#honeycomb_client` so that it can be customized similarly to the application-level client.
- Overhauled the specs, which had not been very extensive previously. You can still see the original test in the form of the `test:client:access` task.

With this, you can selectively disable individual Rake tasks' auto-generated spans by saying

```ruby
Rake::Task["resque:work"].honeycomb_client = nil
```

Alternatively, you could disable Rake at the application level and opt-in to the tracing at the task level:

```ruby
Rake.application.honeycomb_client = nil
Rake::Task["db:migrate"].honeycomb_client = Honeycomb.client
```

Other thoughts:
- I refrained from elevating this to a `Honeycomb::Configuration` option just to keep the change as simple as possible. It's perhaps not the most user-friendly, but it _is_ maximally flexible: use whatever arbitrary logic you want to toggle the client to `nil`.
- As common as the Resque use case is, I wonder if it might be worth adding something to the Rails generator. :thinking: But then, I haven't tested out which exact Resque spans to disable this way, yet.