### PR TITLE
Update Ruby and puma in the example

### DIFF
--- a/examples/rails52/Dockerfile
+++ b/examples/rails52/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.7.6
 RUN apt-get update -qq && apt-get install -y nodejs sqlite3
 RUN gem install bundler
 WORKDIR /myapp

--- a/examples/rails52/Gemfile
+++ b/examples/rails52/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
-gem 'puma', '~> 3.11'
+gem 'puma', '~> 4.3', '>= 4.3.12'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/examples/rails52/Gemfile
+++ b/examples/rails52/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.8'
+ruby '2.7.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'


### PR DESCRIPTION
## Which problem is this PR solving?

- puma: quiets a dependabot alert originating in the example; not a security problem for users of this library
- ruby: 2.5 was ollllld

