### PR TITLE
drop testing for Faraday 0 under Ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,8 @@ workflows:
                 - redis_4
             exclude:
               - ruby-version: "2.2"
+                gemfile: faraday_0
+              - ruby-version: "2.2"
                 gemfile: faraday_1
               - ruby-version: "2.2"
                 gemfile: rails_52


### PR DESCRIPTION
## Which problem is this PR solving?

- The nightly CI run broke on June 3, 2022 when it picked up [multipart-post v2.2.0](https://rubygems.org/gems/multipart-post/versions/2.2.0) released earlier that day.

![Screen Shot 2022-06-21 at 14 49 55](https://user-images.githubusercontent.com/517302/174875778-d86fdabf-b2df-4ddd-93cb-edcea63820c6.png)

## Short description of the changes

- drop testing for Faraday 0 under Ruby 2.2

## Longer Version

faraday 0.x depends on multipart-post.

multipart-post v2.2.0 started using a method `deprecate_constant` that was added in Ruby 2.3.

Trying to use both results in the following error:

    Failure/Error: require "faraday"

    NoMethodError:
      undefined method `deprecate_constant' for Object:Class
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/multipart/post/parts.rb:152:in `<top (required)>'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/multipart/post/multipartable.rb:23:in `require_relative'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/multipart/post/multipartable.rb:23:in `<top (required)>'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/multipart/post.rb:23:in `require_relative'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/multipart/post.rb:23:in `<top (required)>'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/composite_io.rb:2:in `require_relative'
    # /usr/local/bundle/gems/multipart-post-2.2.0/lib/composite_io.rb:2:in `<top (required)>'
    # /usr/local/bundle/gems/faraday-0.17.5/lib/faraday/upload_io.rb:2:in `require'

Old faraday and old Ruby is not something we want to try to account for in our test suite. Users of this library who are on both can resolve this error by pinning to working versions of multipart-post (~> 2.1.1).




