### PR TITLE
maint: fix nightly build

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -52,6 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
-  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.17.0" : nil
+  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.16.0" : nil
   spec.add_development_dependency "webmock", webmock_version
 end

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -52,5 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
-  spec.add_development_dependency "webmock"
+  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.17.0" : nil
+  spec.add_development_dependency "webmock", webmock_version
 end

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -52,6 +52,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
-  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.15.0" : nil
-  spec.add_development_dependency "webmock", webmock_version
+  if RUBY_VERSION < "2.3.0"
+    spec.add_development_dependency "webmock", "< 3.15.0"
+  else
+    spec.add_development_dependency "webmock"
+  end
 end

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -52,6 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
-  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.16.0" : nil
+  webmock_version = RUBY_VERSION < "2.3.0" ? "< 3.15.0" : nil
   spec.add_development_dependency "webmock", webmock_version
 end


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- nightly builds are [failing](https://app.circleci.com/pipelines/github/honeycombio/beeline-ruby?branch=main)

## Short description of the changes

- webmock requires ruby 2.3+ since version 3.15

