### PR TITLE
maint: add ruby 3.1 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           ruby-version: << parameters.ruby-version >>
           gemfile: root
           command: bundle exec rake rubocop
-  test-older-versions: # older ruby versions are not available as non-deprecated cimg/ruby docker images
+  test-older-versions: # need to use deprecated circleci/ruby images for older ruby versions
     parameters:
       gemfile:
         type: string
@@ -163,7 +163,7 @@ workflows:
                 - main
     jobs:
       - lint
-      - test-older-versions: &test-older-versions # older ruby versions are not available as non-deprecated cimg/ruby docker images
+      - test-older-versions: &test-older-versions # need to use deprecated circleci/ruby images for older ruby versions
           name: test-<< matrix.gemfile >>-ruby_<< matrix.ruby-version >>
           requires:
             - lint
@@ -260,7 +260,7 @@ workflows:
           filters: &regular_filters
               tags:
                 only: /.*/
-      - test-older-versions: # older ruby versions are not available as non-deprecated cimg/ruby docker images
+      - test-older-versions: # need to use deprecated circleci/ruby images for older ruby versions
           <<: *test-older-versions
           filters: *regular_filters
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ workflows:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0"]
+              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
               gemfile:
                 - aws_2
                 - aws_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,18 @@ workflows:
                 gemfile: rails_52
               - ruby-version: "3.0"
                 gemfile: sequel4
+              - ruby-version: "3.1"
+                gemfile: rails_41
+              - ruby-version: "3.1"
+                gemfile: rails_42
+              - ruby-version: "3.1"
+                gemfile: rails_5
+              - ruby-version: "3.1"
+                gemfile: rails_51
+              - ruby-version: "3.1"
+                gemfile: rails_52
+              - ruby-version: "3.1"
+                gemfile: sequel4
 
   beeline:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   build_artifacts:
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.6
     steps:
       - checkout
       - run: mkdir -p ~/artifacts
@@ -45,7 +45,7 @@ jobs:
 
   publish_rubygems:
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.6
     steps:
       - attach_workspace:
           at: ~/
@@ -81,7 +81,7 @@ jobs:
         type: string
         default: "2.6"
     docker:
-        - image: circleci/ruby:<< parameters.ruby-version >>
+        - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
       BUNDLE_GEMFILE: ./Gemfile
     steps:
@@ -96,7 +96,7 @@ jobs:
       ruby-version:
         type: string
     docker:
-        - image: circleci/ruby:<< parameters.ruby-version >>
+        - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
       BUNDLE_GEMFILE: gemfiles/<< parameters.gemfile >>.gemfile
     steps:
@@ -116,7 +116,7 @@ jobs:
         type: string
         default: "2.6"
     docker:
-        - image: circleci/ruby:<< parameters.ruby-version >>
+        - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
       BUNDLE_GEMFILE: ./Gemfile
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,27 @@ jobs:
           ruby-version: << parameters.ruby-version >>
           gemfile: root
           command: bundle exec rake rubocop
+  test-older-versions: # older ruby versions are not available as non-deprecated cimg/ruby docker images
+    parameters:
+      gemfile:
+        type: string
+      ruby-version:
+        type: string
+    docker:
+        - image: circleci/ruby:<< parameters.ruby-version >>
+    environment:
+      BUNDLE_GEMFILE: gemfiles/<< parameters.gemfile >>.gemfile
+    steps:
+      - ruby:
+          ruby-version: << parameters.ruby-version >>
+          gemfile: << parameters.gemfile >>
+          command: bundle exec rake test
+      - store_test_results:
+          path: test/reports
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - coverage
   test:
     parameters:
       gemfile:
@@ -142,13 +163,43 @@ workflows:
                 - main
     jobs:
       - lint
+      - test-older-versions: &test-older-versions # older ruby versions are not available as non-deprecated cimg/ruby docker images
+          name: test-<< matrix.gemfile >>-ruby_<< matrix.ruby-version >>
+          requires:
+            - lint
+          matrix:
+            parameters:
+              ruby-version: ["2.2", "2.3"]
+              gemfile:
+                - aws_2
+                - aws_3
+                - faraday_0
+                - faraday_1
+                - sequel4
+                - sequel5
+                - sinatra
+                - rack
+                - rails_41
+                - rails_42
+                - rails_5
+                - rails_51
+                - rails_52
+                - redis_3
+                - redis_4
+            exclude:
+              - ruby-version: "2.2"
+                gemfile: faraday_0
+              - ruby-version: "2.2"
+                gemfile: faraday_1
+              - ruby-version: "2.2"
+                gemfile: rails_52
       - test: &test
           name: test-<< matrix.gemfile >>-ruby_<< matrix.ruby-version >>
           requires:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
+              ruby-version: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
               gemfile:
                 - aws_2
                 - aws_3
@@ -168,22 +219,8 @@ workflows:
                 - redis_3
                 - redis_4
             exclude:
-              - ruby-version: "2.2"
-                gemfile: faraday_0
-              - ruby-version: "2.2"
-                gemfile: faraday_1
-              - ruby-version: "2.2"
-                gemfile: rails_52
-              - ruby-version: "2.2"
-                gemfile: rails_6
-              - ruby-version: "2.3"
-                gemfile: rails_6
               - ruby-version: "2.4"
                 gemfile: rails_6
-              - ruby-version: "2.2"
-                gemfile: rails_61
-              - ruby-version: "2.3"
-                gemfile: rails_61
               - ruby-version: "2.4"
                 gemfile: rails_61
               - ruby-version: "2.4"
@@ -215,6 +252,9 @@ workflows:
           filters: &regular_filters
               tags:
                 only: /.*/
+      - test-older-versions: # older ruby versions are not available as non-deprecated cimg/ruby docker images
+          <<: *test-older-versions
+          filters: *regular_filters
       - test:
           <<: *test
           filters: *regular_filters
@@ -222,6 +262,7 @@ workflows:
           filters: *regular_filters
           requires:
             - test
+            - test-older-versions
       - build_artifacts:
           filters: &tag_filters
               tags:
@@ -231,6 +272,7 @@ workflows:
           requires:
             - lint
             - test
+            - test-older-versions
       - publish_rubygems: &publish
           filters: *tag_filters
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   build_artifacts:
     docker:
-      - image: cimg/ruby:2.6
+      - image: cimg/ruby:2.7
     steps:
       - checkout
       - run: mkdir -p ~/artifacts
@@ -45,7 +45,7 @@ jobs:
 
   publish_rubygems:
     docker:
-      - image: cimg/ruby:2.6
+      - image: cimg/ruby:2.7
     steps:
       - attach_workspace:
           at: ~/
@@ -79,7 +79,7 @@ jobs:
     parameters:
       ruby-version:
         type: string
-        default: "2.6"
+        default: "2.7"
     docker:
         - image: cimg/ruby:<< parameters.ruby-version >>
     environment:
@@ -135,7 +135,7 @@ jobs:
     parameters:
       ruby-version:
         type: string
-        default: "2.6"
+        default: "2.7"
     docker:
         - image: cimg/ruby:<< parameters.ruby-version >>
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,37 +169,7 @@ workflows:
             - lint
           matrix:
             parameters:
-              ruby-version: ["2.2", "2.3"]
-              gemfile:
-                - aws_2
-                - aws_3
-                - faraday_0
-                - faraday_1
-                - sequel4
-                - sequel5
-                - sinatra
-                - rack
-                - rails_41
-                - rails_42
-                - rails_5
-                - rails_51
-                - rails_52
-                - redis_3
-                - redis_4
-            exclude:
-              - ruby-version: "2.2"
-                gemfile: faraday_0
-              - ruby-version: "2.2"
-                gemfile: faraday_1
-              - ruby-version: "2.2"
-                gemfile: rails_52
-      - test: &test
-          name: test-<< matrix.gemfile >>-ruby_<< matrix.ruby-version >>
-          requires:
-            - lint
-          matrix:
-            parameters:
-              ruby-version: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
+              ruby-version: ["2.2", "2.3", "2.4", "2.5", "2.6"]
               gemfile:
                 - aws_2
                 - aws_3
@@ -219,6 +189,20 @@ workflows:
                 - redis_3
                 - redis_4
             exclude:
+              - ruby-version: "2.2"
+                gemfile: faraday_0
+              - ruby-version: "2.2"
+                gemfile: faraday_1
+              - ruby-version: "2.2"
+                gemfile: rails_52
+              - ruby-version: "2.2"
+                gemfile: rails_6
+              - ruby-version: "2.2"
+                gemfile: rails_61
+              - ruby-version: "2.3"
+                gemfile: rails_6
+              - ruby-version: "2.3"
+                gemfile: rails_61
               - ruby-version: "2.4"
                 gemfile: rails_6
               - ruby-version: "2.4"
@@ -229,14 +213,30 @@ workflows:
                 gemfile: rails_41
               - ruby-version: "2.6"
                 gemfile: rails_41
-              - ruby-version: "2.7"
-                gemfile: rails_41
-              - ruby-version: "2.7"
-                gemfile: rails_42
-              - ruby-version: "3.0"
-                gemfile: rails_41
-              - ruby-version: "3.0"
-                gemfile: rails_42
+      - test: &test
+          name: test-<< matrix.gemfile >>-ruby_<< matrix.ruby-version >>
+          requires:
+            - lint
+          matrix:
+            parameters:
+              ruby-version: ["2.7", "3.0", "3.1"]
+              gemfile:
+                - aws_2
+                - aws_3
+                - faraday_0
+                - faraday_1
+                - sequel4
+                - sequel5
+                - sinatra
+                - rack
+                - rails_5
+                - rails_51
+                - rails_52
+                - rails_6
+                - rails_61
+                - redis_3
+                - redis_4
+            exclude:
               - ruby-version: "3.0"
                 gemfile: rails_5
               - ruby-version: "3.0"
@@ -245,10 +245,6 @@ workflows:
                 gemfile: rails_52
               - ruby-version: "3.0"
                 gemfile: sequel4
-              - ruby-version: "3.1"
-                gemfile: rails_41
-              - ruby-version: "3.1"
-                gemfile: rails_42
               - ruby-version: "3.1"
                 gemfile: rails_5
               - ruby-version: "3.1"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- ruby 3.1 was released in December 💎 
- we're currently testing ruby versions 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0
- deprecated `circleci/ruby` does not have an image for 3.1
- new `cimg/ruby` does not have images for 2.2 or 2.3
- 2.4 2.5 and 2.6 images from `cimg/ruby` have a default bundler gem (not the case in deprecated images), and we need a specific (different) version of bundler to test against rails 4.1 and 4.2

## Short description of the changes

- split test in 2: test newer versions (2.7+) with new images and test-older-versions with deprecated images
- update default image to 2.7 since 2.6 is EOL

