### PR TITLE
fix: set min rubocop to avoid false positive lint error

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", ">= 0.5.1"
-  spec.add_development_dependency "rubocop", "< 0.69"
+  spec.add_development_dependency "rubocop", [">= 0.60.0", "< 0.69"]
   spec.add_development_dependency "rubocop-performance", "< 1.3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"


### PR DESCRIPTION
## Which problem is this PR solving?

[v0.60.0](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0600-2018-10-26) includes a fix (6331) for false positives on Regexes assigned to a constant that will quiet the lint error that's appeared in nightly.

Less than v0.69.0 remains for Ruby 2.2 until a time that we decide to overhaul and update dev/test.
