### PR TITLE
ci: use context for publishing ruby gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,7 @@ workflows:
           filters: *tag_filters
           requires:
             - build_artifacts
+          context: Honeycomb Secrets for Public Repos
       - publish_github:
           <<: *publish
           context: Honeycomb Secrets for Public Repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,4 +294,3 @@ workflows:
           context: Honeycomb Secrets for Public Repos
       - publish_github:
           <<: *publish
-          context: Honeycomb Secrets for Public Repos

--- a/.circleci/setup-rubygems.sh
+++ b/.circleci/setup-rubygems.sh
@@ -1,3 +1,3 @@
 mkdir ~/.gem
-echo -e "---\r\n:rubygems_api_key: $GEM_HOST_API_KEY" > ~/.gem/credentials
+echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 chmod 0600 /home/circleci/.gem/credentials


### PR DESCRIPTION
## Short description of the changes

- use circle context for publishing ruby gem
- use `RUBYGEMS_API_KEY` instead of `GEM_HOST_API_KEY`
