### PR TITLE
maint: update author to honeycomb

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/telemetry-team @martin308
+* @honeycombio/telemetry-team

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -7,8 +7,8 @@ require "honeycomb/beeline/version"
 Gem::Specification.new do |spec|
   spec.name          = Honeycomb::Beeline::NAME
   spec.version       = Honeycomb::Beeline::VERSION
-  spec.authors       = ["Martin Holman"]
-  spec.email         = ["martin@honeycomb.io"]
+  spec.authors       = ["Honeycomb"]
+  spec.email         = ["support@honeycomb.io"]
 
   spec.summary       = "Instrument your Ruby apps with Honeycomb"
   spec.homepage      = "https://honeycomb.io"

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -7,7 +7,7 @@ require "honeycomb/beeline/version"
 Gem::Specification.new do |spec|
   spec.name          = Honeycomb::Beeline::NAME
   spec.version       = Honeycomb::Beeline::VERSION
-  spec.authors       = ["Honeycomb"]
+  spec.authors       = ["The Honeycomb.io Team"]
   spec.email         = ["support@honeycomb.io"]
 
   spec.summary       = "Instrument your Ruby apps with Honeycomb"

--- a/lib/honeycomb/beeline/version.rb
+++ b/lib/honeycomb/beeline/version.rb
@@ -3,7 +3,7 @@
 module Honeycomb
   module Beeline
     NAME = "honeycomb-beeline".freeze
-    VERSION = "2.11.1-dev".freeze
+    VERSION = "2.11.0".freeze
     USER_AGENT_SUFFIX = "#{NAME}/#{VERSION}".freeze
   end
 end

--- a/lib/honeycomb/beeline/version.rb
+++ b/lib/honeycomb/beeline/version.rb
@@ -3,7 +3,7 @@
 module Honeycomb
   module Beeline
     NAME = "honeycomb-beeline".freeze
-    VERSION = "2.11.0".freeze
+    VERSION = "2.11.1-dev".freeze
     USER_AGENT_SUFFIX = "#{NAME}/#{VERSION}".freeze
   end
 end


### PR DESCRIPTION
## Short description of the changes

- update author from Martin to Honeycomb
- remove @martin308 from codeowners
- also [confirmed](https://rubygems.org/gems/honeycomb-beeline/versions/2.11.1.pre.dev) with a dev tag that the publish pipeline works for the honeycombio user in rubygems

![we'll take it from here](https://user-images.githubusercontent.com/29520003/214964715-40bffe04-3777-4aeb-aa71-a5ee1b128b11.gif)


