### PR TITLE
docs: add otel recommendation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://circleci.com/gh/honeycombio/beeline-ruby.svg?style=svg)](https://circleci.com/gh/honeycombio/beeline-ruby)
 [![Gem Version](https://badge.fury.io/rb/honeycomb-beeline.svg)](https://badge.fury.io/rb/honeycomb-beeline)
 
+**Note**: Honeycomb embraces OpenTelemetry as the effective way to instrument applications. For any new observability efforts, we recommend [instrumenting with OpenTelemetry](https://docs.honeycomb.io/getting-data-in/opentelemetry/ruby/).
+
 This package makes it easy to instrument your Ruby web app to send useful events to [Honeycomb](https://www.honeycomb.io), a service for debugging your software in production.
 - [Usage and Examples](https://docs.honeycomb.io/getting-data-in/beelines/ruby-beeline/)
 


### PR DESCRIPTION
## Which problem is this PR solving?
This addition to the README makes it clear that Honeycomb recommends instrumenting any new observability efforts with OpenTelemetry

## Short description of the changes
- Add paragraph to README recommending OTel