### PR TITLE
fix: Set loofah dev dependency to < 2.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 .rspec_status
 
 /examples/**/*.lock
+
+# gem lock
+Gemfile.lock

--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bump"
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "loofah", "< 2.21.0"
   spec.add_development_dependency "overcommit", "~> 0.46.0"
   spec.add_development_dependency "pry", "< 0.13.0"
   spec.add_development_dependency "pry-byebug", "~> 3.6.0"


### PR DESCRIPTION
## Which problem is this PR solving?
Beeline nightly tests started to fail once loofah [2.21](https://github.com/flavorjones/loofah/releases/tag/v2.21.0) was released because it requires ruby 2.5 and has a dependency on nokogiri that provides some class overrides for. This led to incompatible versions being selected.

This PR sets max loofah version.

- Closes #224

## Short description of the changes
- Adds loofah < 2.21.0 dev dependency
- Adds Gemfile.lock to .gitignore