### PR TITLE
fix: clean invalid UTF8 from trace field values when generating propagation header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,11 +36,7 @@ Metrics/ParameterLists:
   Max: 6
 
 Style/AccessModifierDeclarations:
-  Exclude:
-    - lib/honeycomb/propagation/aws.rb
-    - lib/honeycomb/propagation/w3c.rb
-    - lib/honeycomb/propagation/honeycomb.rb
-    - lib/honeycomb/propagation/default.rb
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/lib/honeycomb/propagation/default_modern.rb
+++ b/lib/honeycomb/propagation/default_modern.rb
@@ -20,10 +20,8 @@ module Honeycomb
           [nil, nil, nil, nil]
         end
       end
-      # rubocop:disable Style/AccessModifierDeclarations
       module_function :parse_rack_env
       public :parse_rack_env
-      # rubocop:enable Style/AccessModifierDeclarations
     end
   end
 end

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -65,14 +65,11 @@ module Honeycomb
       module_function :clean_data, :clean_string
 
       def to_trace_header
-        fields = clean_data(trace.fields)
-        context = Base64.urlsafe_encode64(JSON.generate(fields)).strip
-        encoded_dataset = URI.encode_www_form_component(builder.dataset)
         data_to_propogate = [
-          "dataset=#{encoded_dataset}",
+          "dataset=#{encode_dataset(builder.dataset)}",
           "trace_id=#{trace.id}",
           "parent_id=#{id}",
-          "context=#{context}",
+          "context=#{encode_trace_fields(trace.fields)}",
         ]
         "1;#{data_to_propogate.join(',')}"
       end
@@ -84,18 +81,28 @@ module Honeycomb
       end
 
       def self.to_trace_header(propagation_context)
-        fields = clean_data(propagation_context.trace_fields)
-        context = Base64.urlsafe_encode64(JSON.generate(fields)).strip
-        dataset = propagation_context.dataset
-        encoded_dataset = URI.encode_www_form_component(dataset)
         data_to_propogate = [
-          "dataset=#{encoded_dataset}",
+          "dataset=#{encode_dataset(propagation_context.dataset)}",
           "trace_id=#{propagation_context.trace_id}",
           "parent_id=#{propagation_context.parent_id}",
-          "context=#{context}",
+          "context=#{encode_trace_fields(propagation_context.trace_fields)}",
         ]
         "1;#{data_to_propogate.join(',')}"
       end
+
+      def encode_trace_fields(fields)
+        Base64.urlsafe_encode64(
+          JSON.generate(
+            clean_data(fields)
+          )
+        ).strip
+      end
+      module_function :encode_trace_fields
+
+      def encode_dataset(dataset)
+        URI.encode_www_form_component(dataset)
+      end
+      module_function :encode_dataset
     end
   end
 end

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -93,8 +93,8 @@ module Honeycomb
       def encode_trace_fields(fields)
         Base64.urlsafe_encode64(
           JSON.generate(
-            clean_data(fields)
-          )
+            clean_data(fields),
+          ),
         ).strip
       end
       module_function :encode_trace_fields

--- a/lib/honeycomb/propagation/honeycomb.rb
+++ b/lib/honeycomb/propagation/honeycomb.rb
@@ -41,7 +41,7 @@ module Honeycomb
           when "parent_id"
             parent_span_id = value
           when "context"
-            Base64.decode64(value).tap do |json|
+            Base64.urlsafe_decode64(value).tap do |json|
               trace_fields = JSON.parse json
             rescue JSON::ParserError
               trace_fields = {}

--- a/lib/honeycomb/propagation/honeycomb_modern.rb
+++ b/lib/honeycomb/propagation/honeycomb_modern.rb
@@ -39,7 +39,7 @@ module Honeycomb
           when "parent_id"
             parent_span_id = value
           when "context"
-            Base64.decode64(value).tap do |json|
+            Base64.urlsafe_decode64(value).tap do |json|
               trace_fields = JSON.parse json
             rescue JSON::ParserError
               trace_fields = {}

--- a/lib/honeycomb/propagation/honeycomb_modern.rb
+++ b/lib/honeycomb/propagation/honeycomb_modern.rb
@@ -63,12 +63,10 @@ module Honeycomb
       module_function :clean_data, :clean_string
 
       def to_trace_header
-        fields = clean_data(trace.fields)
-        context = Base64.urlsafe_encode64(JSON.generate(fields)).strip
         data_to_propogate = [
           "trace_id=#{trace.id}",
           "parent_id=#{id}",
-          "context=#{context}",
+          "context=#{encode_trace_fields(trace.fields)}",
         ]
         "1;#{data_to_propogate.join(',')}"
       end
@@ -80,15 +78,22 @@ module Honeycomb
       end
 
       def self.to_trace_header(propagation_context)
-        fields = clean_data(propagation_context.trace_fields)
-        context = Base64.urlsafe_encode64(JSON.generate(fields)).strip
         data_to_propogate = [
           "trace_id=#{propagation_context.trace_id}",
           "parent_id=#{propagation_context.parent_id}",
-          "context=#{context}",
+          "context=#{encode_trace_fields(propagation_context.trace_fields)}",
         ]
         "1;#{data_to_propogate.join(',')}"
       end
+
+      def encode_trace_fields(fields)
+        Base64.urlsafe_encode64(
+          JSON.generate(
+            clean_data(fields)
+          )
+        ).strip
+      end
+      module_function :encode_trace_fields
     end
   end
 end

--- a/lib/honeycomb/propagation/honeycomb_modern.rb
+++ b/lib/honeycomb/propagation/honeycomb_modern.rb
@@ -89,8 +89,8 @@ module Honeycomb
       def encode_trace_fields(fields)
         Base64.urlsafe_encode64(
           JSON.generate(
-            clean_data(fields)
-          )
+            clean_data(fields),
+          ),
         ).strip
       end
       module_function :encode_trace_fields

--- a/spec/honeycomb/propagation/honeycomb_modern_spec.rb
+++ b/spec/honeycomb/propagation/honeycomb_modern_spec.rb
@@ -77,13 +77,16 @@ RSpec.shared_examples "honeycomb_propagation_parse" do
   end
 
   it "handles previously-encoded invalid utf8" do
-    expected_encoded_fields = "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+    encoded_fields = "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+    expected_fields = { "test" => "honeycomb", "invalid_utf8" => "�" }
+
     serialized_trace =
-      "1;trace_id=trace_id,parent_id=parent_id,context=#{expected_encoded_fields}"
+      "1;trace_id=trace_id,parent_id=parent_id,context=#{encoded_fields}"
+
     expect(propagation.parse(serialized_trace)).to eq [
       "trace_id",
       "parent_id",
-      { "test" => "honeycomb", "invalid_utf8" => "�" },
+      expected_fields,
       nil,
     ]
   end

--- a/spec/honeycomb/propagation/honeycomb_modern_spec.rb
+++ b/spec/honeycomb/propagation/honeycomb_modern_spec.rb
@@ -75,6 +75,17 @@ RSpec.shared_examples "honeycomb_propagation_parse" do
       nil,
     ]
   end
+
+  it "handles previously-encoded invalid utf8" do
+    serialized_trace =
+      "1;trace_id=trace_id,parent_id=parent_id,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+    expect(propagation.parse(serialized_trace)).to eq [
+      "trace_id",
+      "parent_id",
+      { "test" => "honeycomb", "invalid_utf8" => "�" },
+      nil,
+    ]
+  end
 end
 
 RSpec.describe Honeycomb::HoneycombModernPropagation::UnmarshalTraceContext do
@@ -94,24 +105,30 @@ end
 RSpec.describe Honeycomb::HoneycombModernPropagation::MarshalTraceContext do
   describe "module usage" do
     let(:builder) { instance_double("Builder", dataset: "rails") }
-    let(:trace) { instance_double("Trace", id: 2, fields: {}) }
+    let(:trace) { instance_double("Trace", id: 2, fields: {
+      "test" => "honeycomb",
+      "invalid_utf8" => "\xAE",
+    }) }
     let(:span) do
       instance_double("Span", id: 1, trace: trace, builder: builder)
         .extend(subject)
     end
 
-    it "can serialize a basic span and not include the dataset" do
+    it "can serialize a span with fields and handle invalid UTF8 and not include the dataset" do
       expect(span.to_trace_header)
-        .to eq("1;trace_id=2,parent_id=1,context=e30=")
+        .to eq("1;trace_id=2,parent_id=1,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0=")
     end
   end
 
   describe "class method usage" do
-    let(:context) { Honeycomb::Propagation::Context.new(2, 1, {}, "rails") }
+    let(:context) { Honeycomb::Propagation::Context.new(2, 1, {
+      "test" => "honeycomb",
+      "invalid_utf8" => "\xAE",
+    }, "rails") }
 
-    it "can serialize a basic span and not include the dataset" do
+    it "can serialize a span with fields and handle invalid UTF8 and not include the dataset" do
       expect(subject.to_trace_header(context))
-        .to eq("1;trace_id=2,parent_id=1,context=e30=")
+        .to eq("1;trace_id=2,parent_id=1,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0=")
     end
   end
 end
@@ -123,6 +140,7 @@ RSpec.describe "Propagation" do
   let(:fields) do
     {
       "test" => "honeycomb",
+      "invalid_utf8" => "\xAE",
     }
   end
   let(:builder) { instance_double("Builder", dataset: dataset) }
@@ -151,6 +169,9 @@ RSpec.describe "Propagation" do
   end
 
   it "produces the correct fields" do
-    expect(output[2]).to eq fields
+    expect(output[2]).to eq({
+      "test" => "honeycomb",
+      "invalid_utf8" => "�",
+    })
   end
 end

--- a/spec/honeycomb/propagation/honeycomb_spec.rb
+++ b/spec/honeycomb/propagation/honeycomb_spec.rb
@@ -66,13 +66,16 @@ RSpec.shared_examples "honeycomb_propagation_parse" do
   end
 
   it "handles previously-encoded invalid utf8" do
-    expected_encoded_fields = "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+    encoded_fields = "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+    expected_fields = { "test" => "honeycomb", "invalid_utf8" => "�" }
+
     serialized_trace =
-      "1;trace_id=trace_id,parent_id=parent_id,context=#{expected_encoded_fields}"
+      "1;trace_id=trace_id,parent_id=parent_id,context=#{encoded_fields}"
+
     expect(propagation.parse(serialized_trace)).to eq [
       "trace_id",
       "parent_id",
-      { "test" => "honeycomb", "invalid_utf8" => "�" },
+      expected_fields,
       nil,
     ]
   end

--- a/spec/honeycomb/propagation/honeycomb_spec.rb
+++ b/spec/honeycomb/propagation/honeycomb_spec.rb
@@ -66,8 +66,9 @@ RSpec.shared_examples "honeycomb_propagation_parse" do
   end
 
   it "handles previously-encoded invalid utf8" do
+    expected_encoded_fields = "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
     serialized_trace =
-      "1;trace_id=trace_id,parent_id=parent_id,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0="
+      "1;trace_id=trace_id,parent_id=parent_id,context=#{expected_encoded_fields}"
     expect(propagation.parse(serialized_trace)).to eq [
       "trace_id",
       "parent_id",
@@ -92,12 +93,14 @@ RSpec.describe Honeycomb::HoneycombPropagation::UnmarshalTraceContext do
 end
 
 RSpec.describe Honeycomb::HoneycombPropagation::MarshalTraceContext do
+  let(:fields) { { "test" => "honeycomb", "invalid_utf8" => "\xAE" } }
+  let(:expected_encoded_fields) { "eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0=" }
+
   describe "module usage" do
     let(:builder) { instance_double("Builder", dataset: "rails") }
-    let(:trace) { instance_double("Trace", id: 2, fields: {
-      "test" => "honeycomb",
-      "invalid_utf8" => "\xAE",
-    }) }
+    let(:trace) do
+      instance_double("Trace", id: 2, fields: fields)
+    end
     let(:span) do
       instance_double("Span", id: 1, trace: trace, builder: builder)
         .extend(subject)
@@ -105,19 +108,18 @@ RSpec.describe Honeycomb::HoneycombPropagation::MarshalTraceContext do
 
     it "can serialize a span with fields and handle invalid UTF8" do
       expect(span.to_trace_header)
-        .to eq("1;dataset=rails,trace_id=2,parent_id=1,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0=")
+        .to eq("1;dataset=rails,trace_id=2,parent_id=1,context=#{expected_encoded_fields}")
     end
   end
 
   describe "class method usage" do
-    let(:context) { Honeycomb::Propagation::Context.new(2, 1, {
-      "test" => "honeycomb",
-      "invalid_utf8" => "\xAE",
-    }, "rails") }
+    let(:context) do
+      Honeycomb::Propagation::Context.new(2, 1, fields, "rails")
+    end
 
     it "can serialize a span with fields and handle invalid UTF8" do
       expect(subject.to_trace_header(context))
-        .to eq("1;dataset=rails,trace_id=2,parent_id=1,context=eyJ0ZXN0IjoiaG9uZXljb21iIiwiaW52YWxpZF91dGY4Ijoi77-9In0=")
+        .to eq("1;dataset=rails,trace_id=2,parent_id=1,context=#{expected_encoded_fields}")
     end
   end
 end
@@ -158,9 +160,9 @@ RSpec.describe "Propagation" do
   end
 
   it "produces the correct fields" do
-    expect(output[2]).to eq({
+    expect(output[2]).to eq(
       "test" => "honeycomb",
       "invalid_utf8" => "�",
-    })
+    )
   end
 end


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolves #231 

## Short description of the changes

### Tests to Demonstrate the Problem

* Tests added to cover invalid UTF8 characters in trace field values for classic and E&S modes of Honeycomb propagation

### MarshalTraceContext

* Replace invalid UTF8 characters when serializing in Honeycomb-flavored propagators

Mixes in the data cleaning logic already present in Libhoney::Cleaner to prepare trace data for JSON serialization.

* Refactor the encoding logic for serialization in an extracted method to avoid having the two implementations diverge.

### UnmarshalTraceContext

* Decode trace context with the decoder that matches the encoder.

Testing revealed that decoding trace context would fail to produce a string parseable as JSON if some UTF8 characters were included in the data, even if those characters are valid. Because we encode with urlsafe, we need to decode with urlsafe.

### Linting

* Disable the Style/AccessModifierDeclarations Rubocop rule.

Sometimes we group methods under "private", sometimes we inline a symbol reference to a method with "module_method". We remain flexible. This rule does not serve us and we do not serve it.

