### PR TITLE
maint: add local dev notes and fix example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 .rspec_status
 
 /examples/**/*.lock
+
+# intentionally omitting lock files
+Gemfile.lock

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,31 @@
+# Local Development
+
+## Requirements
+
+Ruby: <https://www.ruby-lang.org/en/documentation/installation/>
+
+Rake:
+
+```shell
+gem install rake
+```
+
+## Install dependencies
+
+```shell
+bundle install
+```
+
+## Run Tests
+
+To run all tests:
+
+```shell
+bundle exec rake test
+```
+
+To run individual tests:
+
+```shell
+bundle exec rake test TEST=spec/honeycomb/trace_spec.rb
+```

--- a/examples/rails52/Gemfile
+++ b/examples/rails52/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.3.6'
 # Use Puma as the app server
-gem 'puma', '~> 4.3', '>= 4.3.12'
+gem 'puma', '~> 5.6', '>= 5.6.7'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/examples/rails52/docker-compose.yml
+++ b/examples/rails52/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: redis:latest
 
   squid:
-    image: datadog/squid
+    image: ubuntu/squid
     ports:
       # for reverse proxy back to web app
       - "127.0.0.1:3000:3000"


### PR DESCRIPTION
## Which problem is this PR solving?

- lack of notes on local development
- dependabot alert on example app (example dep, not a security problem for users of this library)

## Short description of the changes

- Add basic `DEVELOPING.md` for when occasional maintenance is necessary
- Replace the `datadog/squid` image in the rails52 example with `ubuntu/squid` because the former has been removed from docker
- Add `Gemfile.lock` to the `.gitignore` file - we already intentionally don't check it in, so this just makes it less likely to inadvertently check it in
- Update puma in rails52 example to quiet dependabot alert

