### PR TITLE
feat: support classic ingest keys

### DIFF
--- a/honeycomb-beeline.gemspec
+++ b/honeycomb-beeline.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "libhoney", ">= 1.14.2"
+  spec.add_dependency "libhoney", ">= 2.3.0"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bump"

--- a/lib/honeycomb/client.rb
+++ b/lib/honeycomb/client.rb
@@ -33,7 +33,7 @@ module Honeycomb
       @libhoney.add_field "service.name", configuration.service_name
       @context = Context.new
 
-      @context.classic = classic_write_key?(configuration.write_key)
+      @context.classic = configuration.classic?
 
       @additional_trace_options = {
         presend_hook: configuration.presend_hook,
@@ -127,10 +127,6 @@ module Honeycomb
       )
       span.add_field("error_backtrace_limit", error_backtrace_limit)
       span.add_field("error_backtrace_total_length", exception.backtrace.length)
-    end
-
-    def classic_write_key?(write_key)
-      write_key.nil? || write_key.length == 32
     end
   end
 end

--- a/lib/honeycomb/configuration.rb
+++ b/lib/honeycomb/configuration.rb
@@ -24,7 +24,7 @@ module Honeycomb
     end
 
     def classic?
-      @write_key.nil? || @write_key.length == 32
+      Libhoney.classic_api_key?(@write_key)
     end
 
     def service_name

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -43,8 +43,26 @@ RSpec.describe Honeycomb::Configuration do
     expect(configuration.write_key).to eq write_key
   end
 
+  describe "#classic?" do
+    it "is true when no key is set" do
+      configuration.write_key = nil
+      expect(configuration.classic?).to be true
+    end
+
+    it "is true with a classic key" do
+      configuration.write_key = "c1a551c000d68f9ed1e96432ac1a3380"
+      expect(configuration.classic?).to be true
+    end
+
+    it "is false with an E&S key" do
+      configuration.write_key = "1234567890123456789012"
+      expect(configuration.classic?).to be false
+    end
+  end
+
   describe "#service_name" do
     it "returns the default unknown-service:<process_name> when not set" do
+      expect(configuration.instance_variable_get(:@service_name)).to be_nil
       # rspec is the expected process name because *this test suite* is rspec
       expect(configuration.service_name).to eq "unknown_service:rspec"
     end
@@ -61,10 +79,12 @@ RSpec.describe Honeycomb::Configuration do
 
     context "with a classic write key" do
       before do
-        configuration.write_key = "c1a551c000d68f9ed1e96432ac1a3380"
+        allow(configuration).to receive(:classic?).and_return(true)
       end
 
       it "returns the value of dataset when service_name isn't set" do
+        expect(configuration.instance_variable_get(:@service_name)).to be_nil
+
         configuration.dataset = "a_dataset"
         expect(configuration.service_name).to eq "a_dataset"
       end
@@ -105,11 +125,12 @@ RSpec.describe Honeycomb::Configuration do
 
     context "with a classic write key" do
       before do
-        configuration.write_key = "c1a551c000d68f9ed1e96432ac1a3380"
+        allow(configuration).to receive(:classic?).and_return(true)
       end
 
       it "returns whatever dataset has been set" do
         expect(configuration.dataset).to be_nil
+
         configuration.dataset = "a_dataset"
         expect(configuration.dataset).to eq "a_dataset"
       end

--- a/spec/honeycomb/configuration_spec.rb
+++ b/spec/honeycomb/configuration_spec.rb
@@ -54,8 +54,23 @@ RSpec.describe Honeycomb::Configuration do
       expect(configuration.classic?).to be true
     end
 
+    it "is true with a classic v3 ingest key" do
+      configuration.write_key = "hcaic_1234567890123456789012345678901234567890123456789012345678"
+      expect(configuration.classic?).to be true
+    end
+
     it "is false with an E&S key" do
       configuration.write_key = "1234567890123456789012"
+      expect(configuration.classic?).to be false
+    end
+
+    it "is false with an E&S v3 ingest key" do
+      configuration.write_key = "hcaik_1234567890123456789012345678901234567890123456789012345678"
+      expect(configuration.classic?).to be false
+    end
+
+    it "is false with a v3 key id only" do
+      configuration.write_key = "hcxik_12345678901234567890123456"
       expect(configuration.classic?).to be false
     end
   end


### PR DESCRIPTION
## Which problem is this PR solving?

- Supporting ingest keys in classic environments

## Short description of the changes

- [x] Consolidated the beeline's classic logic to the Configuration object.
- [x] Spec'd the classic logic directly for the configuration.classic? method and updated other specs to use a stub for classic/not-classic
- [x] Spec'd the new ingest key behavior (which fails)
- [x] Update minimum version of libhoney dependency to [the release](https://github.com/honeycombio/libhoney-rb/releases/tag/v2.3.0) that contains the new [public `Libhoney.classic_api_key?` method](https://github.com/honeycombio/libhoney-rb/pull/138) and use that method for key checking


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206669928045914