### PR TITLE
fix: update S3 integration specs to keep up with changing AWS SDK client shape

### DIFF
--- a/spec/honeycomb/integrations/aws_spec.rb
+++ b/spec/honeycomb/integrations/aws_spec.rb
@@ -579,7 +579,12 @@ if defined?(Honeycomb::Aws)
     describe "s3 region redirect" do
       before do
         # Aws::S3 caches redirected regions, have to reset between tests
-        Aws::S3::BUCKET_REGIONS.clear
+        if Honeycomb::Aws::SDK_VERSION.start_with?("2.")
+          Aws::S3::BUCKET_REGIONS.clear
+        else
+          # BUCKET_REGIONS const removed in v3.149.0
+          Aws::S3.bucket_region_cache.clear
+        end
 
         s3 = Aws::S3::Client.new(honeycomb_client: client)
 

--- a/spec/honeycomb/integrations/aws_spec.rb
+++ b/spec/honeycomb/integrations/aws_spec.rb
@@ -784,15 +784,12 @@ if defined?(Honeycomb::Aws)
           :copy_object,
           status_code: 200,
           headers: {},
-          body: <<-XML,
-            <Response>
-              <Errors>
-                <Error>
-                  <Code>WTF</Code>
-                  <Message>Some special error occurred</Message>
-                </Error>
-              </Errors>
-            </Response>
+          body: <<~XML,
+            <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <Error>
+              <Code>WTF</Code>
+              <Message>Some special error occurred</Message>
+            </Error>
           XML
         )
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Tests on main were breaking in the weekly builds.

## Short description of the changes

- aws-sdk-s3 v3.149.0 removed the `Aws::S3::BUCKET_REGIONS` constant[1] we were using, so switch up to using the accessor method `Aws::S3.bucket_region_cache`.
- aws-sdk-s3 v1.152.3 changed the regex for matching error response bodies[2], so update our stubbed error to keep up.

[1] https://github.com/aws/aws-sdk-ruby/commit/9d55e1f22e7f04ffc598adee949e993a31755cdb#diff-8232dab0dd0010d16882beee85916c9ec1d9b1573e87fb72f29d6530e2951e9cL78
[2] https://github.com/aws/aws-sdk-ruby/commit/49f47130237ba27f43c2c46aa06c3e0620a6086f#diff-38231597d9c2df7aac2db510bd58dbb107727b2e77f0efbf87056075db5e3b31R74

