### PR TITLE
fix: resolve test failures caused by new Sinatra behavior

### DIFF
--- a/spec/honeycomb/integrations/sinatra_spec.rb
+++ b/spec/honeycomb/integrations/sinatra_spec.rb
@@ -8,7 +8,7 @@ if defined?(Honeycomb::Sinatra)
     include Rack::Test::Methods
 
     class App < Sinatra::Application
-      set :host_authorization, { permitted_hosts: [] }
+      set :host_authorization, permitted_hosts: []
 
       get "/" do
         "Hello world"

--- a/spec/honeycomb/integrations/sinatra_spec.rb
+++ b/spec/honeycomb/integrations/sinatra_spec.rb
@@ -8,6 +8,8 @@ if defined?(Honeycomb::Sinatra)
     include Rack::Test::Methods
 
     class App < Sinatra::Application
+      set :host_authorization, { permitted_hosts: [] }
+
       get "/" do
         "Hello world"
       end


### PR DESCRIPTION
## Which problem is this PR solving?

- [Sinatra 4.1.0 introduced a host authorization option to Sinatra apps](https://github.com/sinatra/sinatra/pull/2053). That authorization check was failing requests made in tests.

## Short description of the changes

-  Update the test Sinatra server to allow anybody to talk to it.